### PR TITLE
[PM-35128] Refine manifest shape and content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,4 +106,4 @@ jobs:
             --latest \
             dist/manifest.json \
             dist/checksums.sha256 \
-            dist/maps/**/*.json
+            dist/*.v*.json

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -29,6 +29,36 @@
     },
     "webtests.dev": {
       "pathnames": {
+        "/forms/login/simple": {
+          "forms": [
+            {
+              "category": "account-login",
+              "container": ["form[action='/login']"],
+              "fields": {
+                "username": ["input#username"]
+              },
+              "actions": {
+                "submit": ["button[type='submit']"]
+              }
+            }
+          ]
+        },
+        "/forms/login/ambiguous-inputs": {
+          "forms": [
+            {
+              "category": "account-login",
+              "container": ["div.ambiguous-inputs-container"],
+              "fields": {
+                // The input type for password here is "text"
+                "password": ["input[name='p']"],
+                "username": ["input[name='u']"]
+              },
+              "actions": {
+                "submit": ["button#ambiguous-inputs-go"]
+              }
+            }
+          ]
+        },
         "/forms/login/security-code-multi-input": {
           "forms": [
             {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -118,21 +118,18 @@ const checksums = [];
 mkdirSync(DIST, { recursive: true });
 
 for (const map of maps) {
-  const outDir = join(DIST, "maps", map.name);
-  mkdirSync(outDir, { recursive: true });
-
   // Extract major version for filename suffix
   const majorVersion = map.data.schemaVersion.split(".")[0];
   const versionedName = `${map.name}.v${majorVersion}`;
 
   // Minify data JSON
   const minified = JSON.stringify(map.data);
-  const outDataFile = join(outDir, `${versionedName}.json`);
+  const outDataFile = join(DIST, `${versionedName}.json`);
   writeFileSync(outDataFile, minified);
   console.log(`Minified: ${outDataFile} (${minified.length} bytes)`);
 
   // Copy schema as-is
-  const outSchemaFile = join(outDir, `${versionedName}.schema.json`);
+  const outSchemaFile = join(DIST, `${versionedName}.schema.json`);
   cpSync(map.schemaFile, outSchemaFile);
 
   // Compute content hash for data file

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -92,15 +92,19 @@ if (hasErrors) {
 // Step 3: Optimize and Build Maps
 
 const buildId = process.env.BUILD_ID || `local-${Date.now()}`;
-const gitSha = process.env.GITHUB_SHA || (() => {
-  try {
-    const sha = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
-    const dirty = execSync("git status --porcelain", { encoding: "utf-8" }).trim();
-    return dirty ? `${sha}-dirty` : sha;
-  } catch {
-    return "unknown";
-  }
-})();
+const gitSha =
+  process.env.GITHUB_SHA ||
+  (() => {
+    try {
+      const sha = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+      const dirty = execSync("git status --porcelain", {
+        encoding: "utf-8",
+      }).trim();
+      return dirty ? `${sha}-dirty` : sha;
+    } catch {
+      return "unknown";
+    }
+  })();
 
 const manifest = {
   buildId,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -142,7 +142,7 @@ for (const map of maps) {
     manifest.maps[map.name] = {};
   }
   manifest.maps[map.name][`v${majorVersion}`] = {
-    name: basename(outDataFile),
+    filename: basename(outDataFile),
     cid: `sha256:${dataHash}`,
     schema: basename(outSchemaFile),
   };

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { readFileSync, writeFileSync, mkdirSync, rmSync, cpSync } from "fs";
 import { createHash } from "crypto";
 import { basename, dirname, join, relative } from "path";
@@ -91,7 +92,15 @@ if (hasErrors) {
 // Step 3: Optimize and Build Maps
 
 const buildId = process.env.BUILD_ID || `local-${Date.now()}`;
-const gitSha = process.env.GITHUB_SHA || "unknown";
+const gitSha = process.env.GITHUB_SHA || (() => {
+  try {
+    const sha = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+    const dirty = execSync("git status --porcelain", { encoding: "utf-8" }).trim();
+    return dirty ? `${sha}-dirty` : sha;
+  } catch {
+    return "unknown";
+  }
+})();
 
 const manifest = {
   buildId,
@@ -122,14 +131,20 @@ for (const map of maps) {
   const outSchemaFile = join(outDir, `${versionedName}.schema.json`);
   cpSync(map.schemaFile, outSchemaFile);
 
-  // Record in manifest (array per map to support multiple schema versions)
+  // Compute content hash for data file
+  const dataHash = createHash("sha256")
+    .update(readFileSync(outDataFile))
+    .digest("hex");
+
+  // Record in manifest (object keyed by version)
   if (!manifest.maps[map.name]) {
-    manifest.maps[map.name] = [];
+    manifest.maps[map.name] = {};
   }
-  manifest.maps[map.name].push({
-    schemaVersion: map.data.schemaVersion,
-    files: [relative(DIST, outDataFile), relative(DIST, outSchemaFile)],
-  });
+  manifest.maps[map.name][`v${majorVersion}`] = {
+    name: basename(outDataFile),
+    cid: `sha256:${dataHash}`,
+    schema: basename(outSchemaFile),
+  };
 
   // Compute checksums
   for (const f of [outDataFile, outSchemaFile]) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35128](https://bitwarden.atlassian.net/browse/PM-35128)

## 📔 Objective

- The build file hierarchy has been flattened
- webtests.dev entries have been added to the forms map
- Some adjustments have been made to the manifest shape to improve consumption ergonomics

```diff
 {
   "buildId": "v20260410.1",
   "timestamp": "2026-04-10T13:31:28.913Z",
   "gitSha": "8145b8f7ce91a574d05e2936eeb49b5e6a9f53ab",
   "maps": {
-    "forms": [
-      {
-        "schemaVersion": "1.0.0",
-        "files": [
-          "maps/forms/forms.v1.json",
-          "maps/forms/forms.v1.schema.json"
-        ]
-      }
-    ]
+    "forms": {
+      "v1": {
+        "filename": "forms.v1.json",
+        "cid": "sha256:abcdef...",
+        "schema": "forms.v1.schema.json"
+      }
+    }
   }
 }
```

[PM-35128]: https://bitwarden.atlassian.net/browse/PM-35128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ