### PR TITLE
[PM-33102] Add validation/linting of newly authored forms map entries

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
-  "words": ["Bitwarden", "Punycode", "Iframes"],
+  "words": [
+    "Bitwarden",
+    "combinators",
+    "cspell",
+    "Iframes",
+    "keyserver",
+    "pathname",
+    "pathnames",
+    "Punycode",
+    "targetable"
+  ],
   "flagWords": [],
   "ignorePaths": [
     ".vscode",
@@ -9,6 +19,6 @@
     "**/.git/**",
     "**/node_modules/**",
     "**/package-lock.json",
-    "/project-words.txt"
+    "maps/**/*.jsonc"
   ]
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,4 +31,7 @@ jobs:
         run: npm ci
 
       - name: Run checks
+        env:
+          # Gates inline PR annotations from the forms map selector linter
+          ENABLE_SELECTOR_LINT_PR_FEEDBACK: ${{ vars.ENABLE_SELECTOR_LINT_PR_FEEDBACK }}
         run: npm run check

--- a/maps/forms/README.md
+++ b/maps/forms/README.md
@@ -182,6 +182,7 @@ not Punycode.
 Unicode host keys are normalized to Punycode (ASCII) at build time, ensuring
 that consumers of the built Maps will receive ASCII keys:
 
+<!-- cspell:disable-next-line -->
 - `münchen.de` → built as `xn--mnchen-3ya.de`
 - `例え.jp` → built as `xn--r8jz45g.jp`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "devDependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
+        "css-what": "8.0.0",
         "husky": "9.1.7",
         "lint-staged": "16.4.0",
         "prettier": "3.8.1",
@@ -345,9 +346,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -521,9 +522,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -780,6 +781,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/debug": {
@@ -3707,9 +3722,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "prettier:fix": "prettier --write .",
     "prettier": "prettier --check .",
     "lint:md": "remark . --frail --quiet",
+    "lint:selectors": "node scripts/lint-selectors.mjs",
     "validate": "node scripts/validate-schemas.mjs",
-    "validate:all": "node scripts/validate-schemas.mjs maps/**/*.jsonc",
-    "check": "npm run prettier && npm run lint:md && npm run validate:all",
+    "check": "npm run prettier && npm run lint:md && npm run validate && npm run lint:selectors",
+    "test": "node --test scripts/**/*.test.mjs",
     "build": "node scripts/build.mjs",
     "build:clean": "rm -rf dist && node scripts/build.mjs"
   },
@@ -34,6 +35,9 @@
     "maps/**/*.jsonc": [
       "node scripts/validate-schemas.mjs"
     ],
+    "maps/forms/*.jsonc": [
+      "node scripts/lint-selectors.mjs"
+    ],
     "*.md": [
       "remark --frail --quiet"
     ]
@@ -41,6 +45,7 @@
   "devDependencies": {
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
+    "css-what": "8.0.0",
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "prettier": "3.8.1",

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -147,11 +147,15 @@ export function formatLocation(location) {
   parts.push(`[${location.category}]`);
   parts.push(`${location.kind}.${location.key}`);
 
-  if (location.seqIndex != null) {
-    parts.push(`sequence[${location.seqIndex}]`);
+  // `selectorIndex`: position in the outer alternatives array
+  // `sequenceIndex`: position within a selector sequence (when applicable)
+  // Output reads outside-in: the outer container first, then the inner item.
+  if (location.sequenceIndex != null) {
+    parts.push(`sequence[${location.selectorIndex}]`);
+    parts.push(`[${location.sequenceIndex}]`);
+  } else {
+    parts.push(`[${location.selectorIndex}]`);
   }
-
-  parts.push(`[${location.selectorIndex}]`);
 
   return parts.join(" > ");
 }
@@ -815,13 +819,19 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
       errors.push(...result.errors);
       warnings.push(...result.warnings);
     } else if (Array.isArray(item)) {
-      // Selector sequence - lint each entry in the sequence
-      checkDuplicates(item, { ...context, selectorIndex: i }, errors);
+      // Selector sequence - lint each entry in order.
+      //
+      // Intentionally do NOT dedupe within a sequence. The outer composite
+      // array conveys distinct locations where a single value/concept is
+      // represented; duplicates there are always invalid and caught above.
+      // An inner sequence describes how a single value is split across
+      // inputs at one location, and we expect additional authoring guidance to
+      // use duplicate entries; flagging duplicates here would preclude that.
       for (let j = 0; j < item.length; j++) {
         const result = lintSelector(item[j], {
           ...context,
           selectorIndex: i,
-          seqIndex: j,
+          sequenceIndex: j,
         });
         errors.push(...result.errors);
         warnings.push(...result.warnings);
@@ -831,22 +841,23 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
 }
 
 /**
- * Check for duplicate selector strings within an array.
+ * Check for duplicate selector strings within a top-level alternatives array
+ * (`selectorArray` or `compositeSelectorArray`). Non-string items (e.g., nested
+ * selector sequences) are skipped; duplicates inside a sequence are allowed
+ * and handled by the caller.
  */
 function checkDuplicates(selectors, context, errors) {
   const seen = new Set();
   for (let i = 0; i < selectors.length; i++) {
     const s = typeof selectors[i] === "string" ? selectors[i] : null;
+
     if (s == null) {
       continue;
     }
+
     if (seen.has(s)) {
-      const formattedLocation = formatLocation({
-        ...context,
-        selectorIndex: i,
-      });
       errors.push({
-        location: formattedLocation,
+        location: formatLocation({ ...context, selectorIndex: i }),
         selector: s,
         message: `Duplicate selector "${s}" in the same array. This is likely a copy-paste error.`,
       });

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -26,6 +26,46 @@ const POSITIONAL_PSEUDOS = new Set([
   "last-of-type",
 ]);
 
+/**
+ * Pseudo-classes whose match depends on element state at query time,
+ * which may not be consistent with state at authoring time.
+ */
+const STATE_PSEUDOS = new Set([
+  // User interaction
+  "hover",
+  "focus",
+  "focus-within",
+  "focus-visible",
+  "active",
+  // Link / navigation
+  "link",
+  "visited",
+  "any-link",
+  "local-link",
+  "target",
+  "target-within",
+  // Form state
+  "checked",
+  "indeterminate",
+  "default",
+  "disabled",
+  "enabled",
+  "required",
+  "optional",
+  "valid",
+  "invalid",
+  "user-valid",
+  "user-invalid",
+  "in-range",
+  "out-of-range",
+  "read-only",
+  "read-write",
+  "placeholder-shown",
+  "blank",
+  // Tree content state
+  "empty",
+]);
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -130,6 +170,63 @@ function findPositionalPseudos(tokens) {
     .map((t) => `:${t.name}`);
 }
 
+/**
+ * Find state-dependent pseudo-classes in a token list.
+ */
+function findStatePseudos(tokens) {
+  return tokens
+    .filter((t) => t.type === "pseudo" && STATE_PSEUDOS.has(t.name))
+    .map((t) => `:${t.name}`);
+}
+
+/**
+ * Find pseudo-elements in a token list.
+ */
+function findPseudoElements(tokens) {
+  return tokens
+    .filter((t) => t.type === "pseudo-element")
+    .map((t) => `::${t.name}`);
+}
+
+/**
+ * Find tag tokens whose name starts with "@" (at-rules mis-parsed as tags).
+ */
+function findAtRuleTags(tokens) {
+  return tokens
+    .filter((t) => t.type === "tag" && t.name.startsWith("@"))
+    .map((t) => t.name);
+}
+
+/**
+ * Find namespace-qualified tokens and return readable renderings of each
+ * (e.g., "svg|rect", "*|foo", "[html|lang]").
+ */
+function findNamespacedTokens(tokens) {
+  return tokens
+    .filter((t) => t.namespace != null)
+    .map((t) => {
+      const name = t.name ?? "*";
+      const prefix = t.namespace;
+      const rendering = `${prefix}|${name}`;
+      return t.type === "attribute" ? `[${rendering}]` : rendering;
+    });
+}
+
+/**
+ * Return which sibling combinators (if any) appear in a token list.
+ */
+function findSiblingCombinators(tokens) {
+  const found = [];
+  for (const t of tokens) {
+    if (t.type === "adjacent") {
+      found.push("+");
+    } else if (t.type === "sibling") {
+      found.push("~");
+    }
+  }
+  return found;
+}
+
 // ---------------------------------------------------------------------------
 // Full-selector checks (operate on the raw selector string)
 // ---------------------------------------------------------------------------
@@ -210,9 +307,53 @@ export function lintSelector(raw, location) {
       continue;
     }
 
+    // Selector list (comma) check — fires once per segment
+    if (parsedSelectors.length > 1) {
+      errors.push({
+        location: formattedLocation,
+        selector: raw,
+        message:
+          `Comma-separated selector list in "${segment}" is not allowed. ` +
+          `List each alternative as its own entry in the selector array instead.`,
+      });
+    }
+
     // css-what returns an array of selector lists (comma-separated groups).
     // Each group is an array of tokens.
     for (const tokens of parsedSelectors) {
+      const atRuleTags = findAtRuleTags(tokens);
+      if (atRuleTags.length > 0) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `At-rule token "${atRuleTags[0]}" is not a valid selector. ` +
+            `Remove it; at-rules (\`@media\`, \`@keyframes\`, etc.) only apply to CSS stylesheets, not DOM queries.`,
+        });
+      }
+
+      const pseudoElements = findPseudoElements(tokens);
+      if (pseudoElements.length > 0) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Pseudo-element ${pseudoElements.join(", ")} does not represent a real DOM element. ` +
+            `Target the underlying element directly (e.g., the \`input\` whose placeholder is styled, not \`::placeholder\`).`,
+        });
+      }
+
+      const namespaced = findNamespacedTokens(tokens);
+      if (namespaced.length > 0) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Namespace-qualified token ${namespaced.join(", ")} is not supported. ` +
+            `Forms are matched against HTML elements in the default namespace; remove the namespace prefix.`,
+        });
+      }
+
       if (hasUniversal(tokens)) {
         errors.push({
           location: formattedLocation,
@@ -260,6 +401,31 @@ export function lintSelector(raw, location) {
           selector: raw,
           message:
             `Positional pseudo-class ${positionals.join(", ")} is fragile; it depends on node order which may not be guaranteed. ` +
+            `Prefer targeting by ID, name, or other stable attributes when possible.`,
+        });
+      }
+
+      // State-dependent pseudo-class warning
+      const statePseudos = findStatePseudos(tokens);
+      if (statePseudos.length > 0) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `State-dependent pseudo-class ${statePseudos.join(", ")} matches only when the element is in a specific state; ` +
+            `the field may not be in that state when the selector is consumed. ` +
+            `Prefer targeting by stable attributes when possible.`,
+        });
+      }
+
+      // Sibling combinator warning
+      const siblingCombinators = findSiblingCombinators(tokens);
+      if (siblingCombinators.length > 0) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Sibling combinator ${siblingCombinators.join(", ")} depends on document order, which may not be guaranteed. ` +
             `Prefer targeting by ID, name, or other stable attributes when possible.`,
         });
       }

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -89,6 +89,47 @@ const ROOT_PSEUDOS = new Set(["host", "host-context", "root"]);
  */
 const CONTEXT_DEPENDENT_PSEUDOS = new Set(["scope", "lang", "dir", "defined"]);
 
+/**
+ * Element tags that are unlikely to be the target of a `container` selector
+ * (leaf form controls, void elements, head-only elements). Hitting one of
+ * these in a container usually indicates a field selector placed in the
+ * wrong key.
+ */
+const NON_CONTAINER_TAGS = new Set([
+  "input",
+  "select",
+  "textarea",
+  "button",
+  "option",
+  "optgroup",
+  "a",
+  "img",
+  "br",
+  "hr",
+  "script",
+  "style",
+  "meta",
+  "link",
+  "title",
+]);
+
+/**
+ * Attribute-matcher actions (css-what names) that, with an empty value, are
+ * equivalent to the existence check `[attr]`. Authors who write these almost
+ * always mean something else.
+ */
+const EXISTENCE_EQUIVALENT_ACTIONS = new Map([
+  ["any", "*="],
+  ["start", "^="],
+  ["end", "$="],
+]);
+
+/**
+ * Attribute-matcher actions (css-what names) that, with an empty value, match
+ * no elements at all. `~=` requires a non-empty whitespace-separated word.
+ */
+const ALWAYS_FALSE_EMPTY_ACTIONS = new Map([["element", "~="]]);
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -277,6 +318,49 @@ function findNamespacedTokens(tokens) {
 }
 
 /**
+ * If the target compound's tag is in NON_CONTAINER_TAGS, return that tag
+ * name; otherwise return null. Used only when linting `container` entries.
+ */
+function findNonContainerTarget(tokens) {
+  const compound = getLastCompound(tokens);
+  const tag = compound.find((t) => t.type === "tag");
+  if (tag && NON_CONTAINER_TAGS.has(tag.name)) {
+    return tag.name;
+  }
+  return null;
+}
+
+/**
+ * Find attribute matchers that use an operator equivalent to existence check
+ * when the value is empty (*=, ^=, $= with empty value).
+ */
+function findExistenceEquivalentEmpty(tokens) {
+  return tokens
+    .filter(
+      (t) =>
+        t.type === "attribute" &&
+        EXISTENCE_EQUIVALENT_ACTIONS.has(t.action) &&
+        t.value === "",
+    )
+    .map((t) => `[${t.name}${EXISTENCE_EQUIVALENT_ACTIONS.get(t.action)}'']`);
+}
+
+/**
+ * Find attribute matchers that match no elements when the value is empty
+ * (~= with empty value).
+ */
+function findAlwaysFalseEmpty(tokens) {
+  return tokens
+    .filter(
+      (t) =>
+        t.type === "attribute" &&
+        ALWAYS_FALSE_EMPTY_ACTIONS.has(t.action) &&
+        t.value === "",
+    )
+    .map((t) => `[${t.name}${ALWAYS_FALSE_EMPTY_ACTIONS.get(t.action)}'']`);
+}
+
+/**
  * Return which sibling combinators (if any) appear in a token list.
  */
 function findSiblingCombinators(tokens) {
@@ -340,6 +424,19 @@ export function lintSelector(raw, location) {
   const warnings = [];
   const formattedLocation = formatLocation(location);
 
+  // Empty-or-whitespace-only selector: schema's minLength:1 allows these
+  // through (e.g. "   "), but they describe nothing.
+  if (raw.trim() === "") {
+    errors.push({
+      location: formattedLocation,
+      selector: raw,
+      message:
+        `Selector is empty or contains only whitespace. ` +
+        `Remove the entry or provide a valid selector.`,
+    });
+    return { errors, warnings };
+  }
+
   // Length warning
   if (raw.length > MAX_SELECTOR_LENGTH) {
     warnings.push({
@@ -364,7 +461,9 @@ export function lintSelector(raw, location) {
 
   // Parse and check each segment between >>> boundaries
   const segments = splitBoundarySegments(raw);
-  for (const segment of segments) {
+  for (let segIndex = 0; segIndex < segments.length; segIndex++) {
+    const segment = segments[segIndex];
+    const isFinalSegment = segIndex === segments.length - 1;
     let parsedSelectors;
     try {
       parsedSelectors = parseCss(segment);
@@ -373,6 +472,20 @@ export function lintSelector(raw, location) {
         location: formattedLocation,
         selector: raw,
         message: `Invalid CSS syntax in segment "${segment}" - ${e.message}`,
+      });
+      continue;
+    }
+
+    // An empty parse result means the segment is empty or whitespace-only
+    // (css-what returns [] rather than throwing for these). In a >>> chain
+    // this manifests as ">>>" with blank content between two crossings.
+    if (parsedSelectors.length === 0) {
+      errors.push({
+        location: formattedLocation,
+        selector: raw,
+        message:
+          `Segment between ">>>" combinators is empty or contains only whitespace. ` +
+          `Remove the extra ">>>" or provide a selector for the boundary crossing.`,
       });
       continue;
     }
@@ -540,6 +653,48 @@ export function lintSelector(raw, location) {
             `Prefer including the element type (e.g., \`input#email\`) for added specificity and in cases where ids are (inappropriately) duplicated.`,
         });
       }
+
+      // Empty-value attribute matcher errors (top-level only; nested
+      // inside :not() may be intentional — e.g., "has no class attr").
+      const existenceEq = findExistenceEquivalentEmpty(tokens);
+      if (existenceEq.length > 0) {
+        const firstAttr = existenceEq[0].match(/\[(\w+)/)?.[1] ?? "attr";
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Attribute matcher ${existenceEq.join(", ")} uses a substring/prefix/suffix operator with an empty value, ` +
+            `which is equivalent to the existence check \`[${firstAttr}]\`. ` +
+            `Either drop the operator and value, or provide a non-empty value to match against.`,
+        });
+      }
+
+      const alwaysFalse = findAlwaysFalseEmpty(tokens);
+      if (alwaysFalse.length > 0) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Attribute matcher ${alwaysFalse.join(", ")} uses \`~=\` with an empty value, ` +
+            `which requires a non-empty whitespace-separated word and so matches no elements. ` +
+            `Either drop the operator and value, or provide a non-empty word to match against.`,
+        });
+      }
+
+      // Container-misuse warning: only when linting a `container` entry,
+      // and only on the final segment (the actual target after any >>>).
+      if (location.kind === "container" && isFinalSegment) {
+        const badTag = findNonContainerTarget(tokens);
+        if (badTag) {
+          warnings.push({
+            location: formattedLocation,
+            selector: raw,
+            message:
+              `Container selector targets <${badTag}>, which is not typically a wrapping element. ` +
+              `If this selector identifies a form field, move it under \`fields\`; if it identifies an action, move it under \`actions\`.`,
+          });
+        }
+      }
     }
   }
 
@@ -635,7 +790,7 @@ function lintForms(forms, context, errors, warnings) {
  * Lint a selectorArray (array of selector strings).
  */
 function lintSelectorArray(selectors, context, errors, warnings) {
-  checkDuplicates(selectors, context, warnings);
+  checkDuplicates(selectors, context, errors);
 
   for (let i = 0; i < selectors.length; i++) {
     const result = lintSelector(selectors[i], { ...context, selectorIndex: i });
@@ -651,7 +806,7 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
   // Duplicate check on top-level string entries. Pass the original array so
   // the reported selectorIndex reflects the author's file position; nested
   // sequence arrays are skipped by `checkDuplicates`'s non-string guard.
-  checkDuplicates(selectors, context, warnings);
+  checkDuplicates(selectors, context, errors);
 
   for (let i = 0; i < selectors.length; i++) {
     const item = selectors[i];
@@ -661,7 +816,7 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
       warnings.push(...result.warnings);
     } else if (Array.isArray(item)) {
       // Selector sequence - lint each entry in the sequence
-      checkDuplicates(item, { ...context, selectorIndex: i }, warnings);
+      checkDuplicates(item, { ...context, selectorIndex: i }, errors);
       for (let j = 0; j < item.length; j++) {
         const result = lintSelector(item[j], {
           ...context,
@@ -678,7 +833,7 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
 /**
  * Check for duplicate selector strings within an array.
  */
-function checkDuplicates(selectors, context, warnings) {
+function checkDuplicates(selectors, context, errors) {
   const seen = new Set();
   for (let i = 0; i < selectors.length; i++) {
     const s = typeof selectors[i] === "string" ? selectors[i] : null;
@@ -690,7 +845,7 @@ function checkDuplicates(selectors, context, warnings) {
         ...context,
         selectorIndex: i,
       });
-      warnings.push({
+      errors.push({
         location: formattedLocation,
         selector: s,
         message: `Duplicate selector "${s}" in the same array. This is likely a copy-paste error.`,

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -384,22 +384,37 @@ function findSiblingCombinators(tokens) {
 // ---------------------------------------------------------------------------
 
 /**
- * Validate boundary combinator (>>>) usage. Returns an error message if
- * the combinator appears at the start or end of the selector.
+ * Validate boundary combinator (>>>) usage at the edges of the raw selector.
+ *
+ * Returns an object carrying:
+ *   - messages: zero, one, or two error messages (start and/or end misuse).
+ *     A selector like ">>> x >>>" can misuse the combinator at both ends.
+ *   - sanitized: the selector with any leading/trailing ">>>" stripped, so
+ *     the caller can keep aggregating other errors against the remainder
+ *     rather than bailing at the first boundary violation.
  */
 function checkBoundaryCombinator(raw) {
-  const trimmed = raw.trim();
-  if (!trimmed.includes(BOUNDARY_COMBINATOR)) {
-    return null;
+  let sanitized = raw.trim();
+  const messages = [];
+
+  if (!sanitized.includes(BOUNDARY_COMBINATOR)) {
+    return { messages, sanitized };
   }
 
-  if (trimmed.startsWith(BOUNDARY_COMBINATOR)) {
-    return `Selector starts with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a host element reference on the left side`;
+  if (sanitized.startsWith(BOUNDARY_COMBINATOR)) {
+    messages.push(
+      `Selector starts with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a host element reference on the left side`,
+    );
+    sanitized = sanitized.slice(BOUNDARY_COMBINATOR.length).trim();
   }
-  if (trimmed.endsWith(BOUNDARY_COMBINATOR)) {
-    return `Selector ends with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a target selector on the right side`;
+  if (sanitized.endsWith(BOUNDARY_COMBINATOR)) {
+    messages.push(
+      `Selector ends with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a target selector on the right side`,
+    );
+    sanitized = sanitized.slice(0, -BOUNDARY_COMBINATOR.length).trim();
   }
-  return null;
+
+  return { messages, sanitized };
 }
 
 /**
@@ -452,14 +467,20 @@ export function lintSelector(raw, location) {
     });
   }
 
-  // Boundary combinator structural check
-  const boundaryError = checkBoundaryCombinator(raw);
-  if (boundaryError) {
-    errors.push({
-      location: formattedLocation,
-      selector: raw,
-      message: boundaryError,
-    });
+  // Boundary combinator structural check. Collect any edge-misuse errors
+  // and continue processing against the sanitized remainder so the author
+  // gets all applicable errors (e.g., boundary misuse *and* a bare-element
+  // target) in one pass rather than having to fix them serially.
+  const { messages: boundaryMessages, sanitized } =
+    checkBoundaryCombinator(raw);
+  for (const message of boundaryMessages) {
+    errors.push({ location: formattedLocation, selector: raw, message });
+  }
+
+  // If stripping the edge-misuse tokens left nothing to lint, stop here;
+  // further checks would either throw or emit a redundant empty-segment
+  // error for what is really the same problem.
+  if (sanitized === "") {
     return { errors, warnings };
   }
 
@@ -468,7 +489,7 @@ export function lintSelector(raw, location) {
   // `parseCss` avoids relying on parser behavior for `""` (which returns `[]`
   // rather than throwing) and makes the remediation message specific to
   // the `">>>"` chain case.
-  const segments = splitBoundarySegments(raw);
+  const segments = splitBoundarySegments(sanitized);
   for (let segIndex = 0; segIndex < segments.length; segIndex++) {
     const segment = segments[segIndex];
     const isFinalSegment = segIndex === segments.length - 1;

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -1,0 +1,434 @@
+import { parse as parseCss } from "css-what";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BOUNDARY_COMBINATOR = ">>>";
+const MAX_COMBINATOR_DEPTH = 4;
+const MAX_SELECTOR_LENGTH = 200;
+
+const COMBINATOR_TYPES = new Set([
+  "child",
+  "descendant",
+  "sibling",
+  "adjacent",
+]);
+
+const POSITIONAL_PSEUDOS = new Set([
+  "nth-child",
+  "nth-of-type",
+  "nth-last-child",
+  "nth-last-of-type",
+  "first-child",
+  "last-child",
+  "first-of-type",
+  "last-of-type",
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a location object into a readable path string.
+ */
+export function formatLocation(location) {
+  const parts = [location.host];
+
+  if (location.pathname) {
+    parts.push(location.pathname);
+  }
+
+  parts.push(`[${location.category}]`);
+  parts.push(`${location.kind}.${location.key}`);
+
+  if (location.seqIndex != null) {
+    parts.push(`sequence[${location.seqIndex}]`);
+  }
+
+  parts.push(`[${location.selectorIndex}]`);
+
+  return parts.join(" > ");
+}
+
+// ---------------------------------------------------------------------------
+// Segment-level checks (operate on a single CSS segment between >>> tokens)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a parsed selector segment is "bare"; only an element tag
+ * with no qualifying ID, class, attribute, or pseudo-class.
+ */
+function isBareElement(tokens) {
+  const compound = getLastCompound(tokens);
+  return compound.length === 1 && compound[0].type === "tag";
+}
+
+/**
+ * Check whether a parsed selector segment is class-only; one or more class
+ * selectors with no element, ID, attribute, or pseudo-class qualifier.
+ */
+function isClassOnly(tokens) {
+  const compound = getLastCompound(tokens);
+  return (
+    compound.length > 0 &&
+    compound.every(
+      (t) =>
+        t.type === "attribute" && t.name === "class" && t.action === "element",
+    )
+  );
+}
+
+/**
+ * Check whether a parsed selector segment contains a universal selector.
+ */
+function hasUniversal(tokens) {
+  return tokens.some((t) => t.type === "universal");
+}
+
+/**
+ * Check whether a parsed selector segment is ID-only; a single ID selector
+ * with no element type or other qualifier on the target compound.
+ */
+function isIdOnly(tokens) {
+  const compound = getLastCompound(tokens);
+  return (
+    compound.length === 1 &&
+    compound[0].type === "attribute" &&
+    compound[0].name === "id" &&
+    compound[0].action === "equals"
+  );
+}
+
+/**
+ * Return the last compound selector (tokens after the final combinator).
+ */
+function getLastCompound(tokens) {
+  let start = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    if (COMBINATOR_TYPES.has(tokens[i].type)) {
+      start = i + 1;
+    }
+  }
+  return tokens.slice(start);
+}
+
+/**
+ * Count the number of combinators (nesting depth) in a token list.
+ */
+function combinatorDepth(tokens) {
+  return tokens.filter((t) => COMBINATOR_TYPES.has(t.type)).length;
+}
+
+/**
+ * Find positional pseudo-classes in a token list.
+ */
+function findPositionalPseudos(tokens) {
+  return tokens
+    .filter((t) => t.type === "pseudo" && POSITIONAL_PSEUDOS.has(t.name))
+    .map((t) => `:${t.name}`);
+}
+
+// ---------------------------------------------------------------------------
+// Full-selector checks (operate on the raw selector string)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate boundary combinator (>>>) usage. Returns an error message if
+ * the combinator appears at the start or end of the selector.
+ */
+function checkBoundaryCombinator(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed.includes(BOUNDARY_COMBINATOR)) {
+    return null;
+  }
+
+  if (trimmed.startsWith(BOUNDARY_COMBINATOR)) {
+    return `Selector starts with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a host element reference on the left side`;
+  }
+  if (trimmed.endsWith(BOUNDARY_COMBINATOR)) {
+    return `Selector ends with "${BOUNDARY_COMBINATOR}" - a boundary crossing requires a target selector on the right side`;
+  }
+  return null;
+}
+
+/**
+ * Split a selector string on the >>> boundary combinator, returning the
+ * individual CSS segments to parse independently.
+ */
+function splitBoundarySegments(raw) {
+  return raw.split(BOUNDARY_COMBINATOR).map((s) => s.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Core lint logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Lint a single selector string. Returns { errors: [], warnings: [] }.
+ */
+export function lintSelector(raw, location) {
+  const errors = [];
+  const warnings = [];
+  const formattedLocation = formatLocation(location);
+
+  // Length warning
+  if (raw.length > MAX_SELECTOR_LENGTH) {
+    warnings.push({
+      location: formattedLocation,
+      selector: raw,
+      message:
+        `Selector is ${raw.length} characters long (>${MAX_SELECTOR_LENGTH}). ` +
+        `Consider scoping with a "container" or simplifying the selector chain.`,
+    });
+  }
+
+  // Boundary combinator structural check
+  const boundaryError = checkBoundaryCombinator(raw);
+  if (boundaryError) {
+    errors.push({
+      location: formattedLocation,
+      selector: raw,
+      message: boundaryError,
+    });
+    return { errors, warnings };
+  }
+
+  // Parse and check each segment between >>> boundaries
+  const segments = splitBoundarySegments(raw);
+  for (const segment of segments) {
+    let parsedSelectors;
+    try {
+      parsedSelectors = parseCss(segment);
+    } catch (e) {
+      errors.push({
+        location: formattedLocation,
+        selector: raw,
+        message: `Invalid CSS syntax in segment "${segment}" - ${e.message}`,
+      });
+      continue;
+    }
+
+    // css-what returns an array of selector lists (comma-separated groups).
+    // Each group is an array of tokens.
+    for (const tokens of parsedSelectors) {
+      if (hasUniversal(tokens)) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Universal selector "*" is not allowed. ` +
+            `Replace with a specific element type, ID, or attribute selector.`,
+        });
+      } else if (isBareElement(tokens)) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Bare element selector "${segment}" has no qualifying ID, attribute, or class. ` +
+            `Add a qualifier (e.g., \`input#id\`, \`input[name='x']\`, \`input.class\`) to avoid mis-targeting.`,
+        });
+      } else if (isClassOnly(tokens)) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Class-only selector "${segment}" is not specific enough. ` +
+            `Add an element type or attribute qualifier (e.g., \`button.submit\`, \`.submit[type='submit']\`).`,
+        });
+      }
+
+      // Deep nesting warning
+      const depth = combinatorDepth(tokens);
+      if (depth > MAX_COMBINATOR_DEPTH) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Selector has ${depth} levels of nesting (>${MAX_COMBINATOR_DEPTH}). ` +
+            `Deeply nested selectors are brittle; they break when distant ancestors change. ` +
+            `Consider scoping with a "container" to reduce nesting depth.`,
+        });
+      }
+
+      // Positional pseudo-class warning
+      const positionals = findPositionalPseudos(tokens);
+      if (positionals.length > 0) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Positional pseudo-class ${positionals.join(", ")} is fragile; it depends on node order which may not be guaranteed. ` +
+            `Prefer targeting by ID, name, or other stable attributes when possible.`,
+        });
+      }
+
+      // ID-only target warning
+      if (isIdOnly(tokens)) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `ID-only selector "${segment}" omits the element type. ` +
+            `Prefer including the element type (e.g., \`input#email\`) for added specificity and in cases where ids are (inappropriately) duplicated.`,
+        });
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+/**
+ * Extract and lint all selectors from a parsed map data object.
+ */
+export function lintMapData(data) {
+  const allErrors = [];
+  const allWarnings = [];
+
+  if (!data.hosts) {
+    return { errors: allErrors, warnings: allWarnings };
+  }
+
+  for (const [host, hostEntry] of Object.entries(data.hosts)) {
+    if (hostEntry == null) {
+      continue;
+    }
+
+    // Host-level forms
+    if (hostEntry.forms) {
+      lintForms(hostEntry.forms, { host }, allErrors, allWarnings);
+    }
+
+    // Pathname-level forms
+    if (hostEntry.pathnames) {
+      for (const [pathname, pathEntry] of Object.entries(hostEntry.pathnames)) {
+        if (pathEntry == null) {
+          continue;
+        }
+        if (pathEntry.forms) {
+          lintForms(
+            pathEntry.forms,
+            { host, pathname },
+            allErrors,
+            allWarnings,
+          );
+        }
+      }
+    }
+  }
+
+  return { errors: allErrors, warnings: allWarnings };
+}
+
+/**
+ * Lint all selectors within a forms array.
+ */
+function lintForms(forms, context, errors, warnings) {
+  for (const form of forms) {
+    const category = form.category || "unknown";
+
+    // Container selectors
+    if (form.container) {
+      lintSelectorArray(
+        form.container,
+        { ...context, category, kind: "container", key: "container" },
+        errors,
+        warnings,
+      );
+    }
+
+    // Field selectors
+    if (form.fields) {
+      for (const [fieldKey, selectors] of Object.entries(form.fields)) {
+        lintCompositeSelectorArray(
+          selectors,
+          { ...context, category, kind: "fields", key: fieldKey },
+          errors,
+          warnings,
+        );
+      }
+    }
+
+    // Action selectors
+    if (form.actions) {
+      for (const [actionKey, selectors] of Object.entries(form.actions)) {
+        lintSelectorArray(
+          selectors,
+          { ...context, category, kind: "actions", key: actionKey },
+          errors,
+          warnings,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Lint a selectorArray (array of selector strings).
+ */
+function lintSelectorArray(selectors, context, errors, warnings) {
+  checkDuplicates(selectors, context, warnings);
+
+  for (let i = 0; i < selectors.length; i++) {
+    const result = lintSelector(selectors[i], { ...context, selectorIndex: i });
+    errors.push(...result.errors);
+    warnings.push(...result.warnings);
+  }
+}
+
+/**
+ * Lint a compositeSelectorArray (items can be strings or arrays of strings).
+ */
+function lintCompositeSelectorArray(selectors, context, errors, warnings) {
+  // Duplicate check on top-level string entries only
+  const topLevelStrings = selectors.filter((s) => typeof s === "string");
+  checkDuplicates(topLevelStrings, context, warnings);
+
+  for (let i = 0; i < selectors.length; i++) {
+    const item = selectors[i];
+    if (typeof item === "string") {
+      const result = lintSelector(item, { ...context, selectorIndex: i });
+      errors.push(...result.errors);
+      warnings.push(...result.warnings);
+    } else if (Array.isArray(item)) {
+      // Selector sequence - lint each entry in the sequence
+      checkDuplicates(item, { ...context, selectorIndex: i }, warnings);
+      for (let j = 0; j < item.length; j++) {
+        const result = lintSelector(item[j], {
+          ...context,
+          selectorIndex: i,
+          seqIndex: j,
+        });
+        errors.push(...result.errors);
+        warnings.push(...result.warnings);
+      }
+    }
+  }
+}
+
+/**
+ * Check for duplicate selector strings within an array.
+ */
+function checkDuplicates(selectors, context, warnings) {
+  const seen = new Set();
+  for (let i = 0; i < selectors.length; i++) {
+    const s = typeof selectors[i] === "string" ? selectors[i] : null;
+    if (s == null) {
+      continue;
+    }
+    if (seen.has(s)) {
+      const formattedLocation = formatLocation({
+        ...context,
+        selectorIndex: i,
+      });
+      warnings.push({
+        location: formattedLocation,
+        selector: s,
+        message: `Duplicate selector "${s}" in the same array. This is likely a copy-paste error.`,
+      });
+    }
+    seen.add(s);
+  }
+}

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -185,6 +185,29 @@ function combinatorDepth(tokens) {
 }
 
 /**
+ * Walk a token list, yielding every token including those nested inside
+ * functional pseudo-classes (e.g., :not(...), :is(...), :has(...)).
+ * Pseudos with string .data (e.g., :lang("en")) are not descended into.
+ */
+function* walkTokens(tokens) {
+  for (const t of tokens) {
+    yield t;
+    if (t.type === "pseudo" && Array.isArray(t.data)) {
+      for (const subGroup of t.data) {
+        yield* walkTokens(subGroup);
+      }
+    }
+  }
+}
+
+/**
+ * Return a flat array of every token, descending into functional pseudos.
+ */
+function collectAllTokens(tokens) {
+  return [...walkTokens(tokens)];
+}
+
+/**
  * Find positional pseudo-classes in a token list.
  */
 function findPositionalPseudos(tokens) {
@@ -294,6 +317,12 @@ function checkBoundaryCombinator(raw) {
 /**
  * Split a selector string on the >>> boundary combinator, returning the
  * individual CSS segments to parse independently.
+ *
+ * Known limitation: this is a naive string split and will misinterpret ">>>"
+ * if it appears literally inside an attribute value (e.g., `[data-x=">>>"]`).
+ * This has not come up in practice for form selectors; if it does, this
+ * should be replaced with a tokenizing split that respects bracket/quote
+ * regions.
  */
 function splitBoundarySegments(raw) {
   return raw.split(BOUNDARY_COMBINATOR).map((s) => s.trim());
@@ -362,7 +391,11 @@ export function lintSelector(raw, location) {
     // css-what returns an array of selector lists (comma-separated groups).
     // Each group is an array of tokens.
     for (const tokens of parsedSelectors) {
-      const atRuleTags = findAtRuleTags(tokens);
+      // Token-level checks that should also apply inside functional pseudos
+      // (e.g., :not(:nth-child(2)) still carries positional fragility).
+      const allTokens = collectAllTokens(tokens);
+
+      const atRuleTags = findAtRuleTags(allTokens);
       if (atRuleTags.length > 0) {
         errors.push({
           location: formattedLocation,
@@ -373,7 +406,7 @@ export function lintSelector(raw, location) {
         });
       }
 
-      const pseudoElements = findPseudoElements(tokens);
+      const pseudoElements = findPseudoElements(allTokens);
       if (pseudoElements.length > 0) {
         errors.push({
           location: formattedLocation,
@@ -384,7 +417,7 @@ export function lintSelector(raw, location) {
         });
       }
 
-      const namespaced = findNamespacedTokens(tokens);
+      const namespaced = findNamespacedTokens(allTokens);
       if (namespaced.length > 0) {
         errors.push({
           location: formattedLocation,
@@ -395,7 +428,7 @@ export function lintSelector(raw, location) {
         });
       }
 
-      const rootPseudos = findRootPseudos(tokens);
+      const rootPseudos = findRootPseudos(allTokens);
       if (rootPseudos.length > 0) {
         errors.push({
           location: formattedLocation,
@@ -406,6 +439,8 @@ export function lintSelector(raw, location) {
         });
       }
 
+      // Target-identity checks apply to the top-level compound only;
+      // :not(input) means "not an input", which is not the same as "target an input".
       if (hasUniversal(tokens)) {
         errors.push({
           location: formattedLocation,
@@ -432,7 +467,7 @@ export function lintSelector(raw, location) {
         });
       }
 
-      // Deep nesting warning
+      // Deep nesting warning — top-level structural concern only.
       const depth = combinatorDepth(tokens);
       if (depth > MAX_COMBINATOR_DEPTH) {
         warnings.push({
@@ -446,7 +481,7 @@ export function lintSelector(raw, location) {
       }
 
       // Positional pseudo-class warning
-      const positionals = findPositionalPseudos(tokens);
+      const positionals = findPositionalPseudos(allTokens);
       if (positionals.length > 0) {
         warnings.push({
           location: formattedLocation,
@@ -458,7 +493,7 @@ export function lintSelector(raw, location) {
       }
 
       // State-dependent pseudo-class warning
-      const statePseudos = findStatePseudos(tokens);
+      const statePseudos = findStatePseudos(allTokens);
       if (statePseudos.length > 0) {
         warnings.push({
           location: formattedLocation,
@@ -471,7 +506,7 @@ export function lintSelector(raw, location) {
       }
 
       // Context-dependent pseudo-class warning
-      const contextPseudos = findContextDependentPseudos(tokens);
+      const contextPseudos = findContextDependentPseudos(allTokens);
       if (contextPseudos.length > 0) {
         warnings.push({
           location: formattedLocation,
@@ -484,7 +519,7 @@ export function lintSelector(raw, location) {
       }
 
       // Sibling combinator warning
-      const siblingCombinators = findSiblingCombinators(tokens);
+      const siblingCombinators = findSiblingCombinators(allTokens);
       if (siblingCombinators.length > 0) {
         warnings.push({
           location: formattedLocation,
@@ -613,9 +648,10 @@ function lintSelectorArray(selectors, context, errors, warnings) {
  * Lint a compositeSelectorArray (items can be strings or arrays of strings).
  */
 function lintCompositeSelectorArray(selectors, context, errors, warnings) {
-  // Duplicate check on top-level string entries only
-  const topLevelStrings = selectors.filter((s) => typeof s === "string");
-  checkDuplicates(topLevelStrings, context, warnings);
+  // Duplicate check on top-level string entries. Pass the original array so
+  // the reported selectorIndex reflects the author's file position; nested
+  // sequence arrays are skipped by `checkDuplicates`'s non-string guard.
+  checkDuplicates(selectors, context, warnings);
 
   for (let i = 0; i < selectors.length; i++) {
     const item = selectors[i];

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -463,11 +463,27 @@ export function lintSelector(raw, location) {
     return { errors, warnings };
   }
 
-  // Parse and check each segment between >>> boundaries
+  // Walk each `>>>`-separated segment: (1) reject empties explicitly, then
+  // (2) parse what's left. Keeping the empty-segment check separate from
+  // `parseCss` avoids relying on parser behavior for `""` (which returns `[]`
+  // rather than throwing) and makes the remediation message specific to
+  // the `">>>"` chain case.
   const segments = splitBoundarySegments(raw);
   for (let segIndex = 0; segIndex < segments.length; segIndex++) {
     const segment = segments[segIndex];
     const isFinalSegment = segIndex === segments.length - 1;
+
+    if (segment === "") {
+      errors.push({
+        location: formattedLocation,
+        selector: raw,
+        message:
+          `Segment between ">>>" combinators is empty or contains only whitespace. ` +
+          `Remove the extra ">>>" or provide a selector for the boundary crossing.`,
+      });
+      continue;
+    }
+
     let parsedSelectors;
     try {
       parsedSelectors = parseCss(segment);
@@ -476,20 +492,6 @@ export function lintSelector(raw, location) {
         location: formattedLocation,
         selector: raw,
         message: `Invalid CSS syntax in segment "${segment}" - ${e.message}`,
-      });
-      continue;
-    }
-
-    // An empty parse result means the segment is empty or whitespace-only
-    // (css-what returns [] rather than throwing for these). In a >>> chain
-    // this manifests as ">>>" with blank content between two crossings.
-    if (parsedSelectors.length === 0) {
-      errors.push({
-        location: formattedLocation,
-        selector: raw,
-        message:
-          `Segment between ">>>" combinators is empty or contains only whitespace. ` +
-          `Remove the extra ">>>" or provide a selector for the boundary crossing.`,
       });
       continue;
     }

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -62,9 +62,32 @@ const STATE_PSEUDOS = new Set([
   "read-write",
   "placeholder-shown",
   "blank",
+  // Dialog / popover / details state
+  "modal",
+  "open",
+  "closed",
+  "popover-open",
+  // Media / viewport state
+  "fullscreen",
+  "picture-in-picture",
   // Tree content state
   "empty",
 ]);
+
+/**
+ * Pseudo-classes that reference a root or shadow-root context rather than a
+ * form field. We cross shadow boundaries with ">>>", so these are redundant
+ * or point at elements that cannot be form fields.
+ */
+const ROOT_PSEUDOS = new Set(["host", "host-context", "root"]);
+
+/**
+ * Pseudo-classes whose behavior depends on the query-time context
+ * (caller's scope, document language/direction, custom element registration).
+ * Their outcomes are not controlled by the map and make selectors less
+ * portable across consumers.
+ */
+const CONTEXT_DEPENDENT_PSEUDOS = new Set(["scope", "lang", "dir", "defined"]);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -176,6 +199,24 @@ function findPositionalPseudos(tokens) {
 function findStatePseudos(tokens) {
   return tokens
     .filter((t) => t.type === "pseudo" && STATE_PSEUDOS.has(t.name))
+    .map((t) => `:${t.name}`);
+}
+
+/**
+ * Find root / shadow-root pseudo-classes in a token list.
+ */
+function findRootPseudos(tokens) {
+  return tokens
+    .filter((t) => t.type === "pseudo" && ROOT_PSEUDOS.has(t.name))
+    .map((t) => `:${t.name}`);
+}
+
+/**
+ * Find context-dependent pseudo-classes in a token list.
+ */
+function findContextDependentPseudos(tokens) {
+  return tokens
+    .filter((t) => t.type === "pseudo" && CONTEXT_DEPENDENT_PSEUDOS.has(t.name))
     .map((t) => `:${t.name}`);
 }
 
@@ -354,6 +395,17 @@ export function lintSelector(raw, location) {
         });
       }
 
+      const rootPseudos = findRootPseudos(tokens);
+      if (rootPseudos.length > 0) {
+        errors.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Root-context pseudo-class ${rootPseudos.join(", ")} does not represent a form field. ` +
+            `Target the field element directly; use ">>>" to cross shadow boundaries when needed.`,
+        });
+      }
+
       if (hasUniversal(tokens)) {
         errors.push({
           location: formattedLocation,
@@ -414,6 +466,19 @@ export function lintSelector(raw, location) {
           message:
             `State-dependent pseudo-class ${statePseudos.join(", ")} matches only when the element is in a specific state; ` +
             `the field may not be in that state when the selector is consumed. ` +
+            `Prefer targeting by stable attributes when possible.`,
+        });
+      }
+
+      // Context-dependent pseudo-class warning
+      const contextPseudos = findContextDependentPseudos(tokens);
+      if (contextPseudos.length > 0) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Context-dependent pseudo-class ${contextPseudos.join(", ")} depends on how the consumer queries the page ` +
+            `(scope, document language/direction, custom element registration). ` +
             `Prefer targeting by stable attributes when possible.`,
         });
       }

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -539,6 +539,69 @@ describe("state-dependent pseudo-classes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Nested fragility inside functional pseudo-classes
+// ---------------------------------------------------------------------------
+
+describe("nested fragility inside functional pseudos", () => {
+  it("warns on a positional pseudo nested inside :not()", () => {
+    const warnings = warningsFor("input#email:not(:nth-child(2))");
+    const positional = warnings.filter((w) =>
+      /Positional pseudo-class/.test(w.message),
+    );
+    assert.equal(positional.length, 1);
+    assert.match(positional[0].message, /:nth-child/);
+  });
+
+  it("warns on a state pseudo nested inside :is()", () => {
+    const warnings = warningsFor("input#email:is(:hover, :focus)");
+    const state = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(state.length, 1);
+  });
+
+  it("warns on a sibling combinator nested inside :has()", () => {
+    const warnings = warningsFor("form#login:has(+ button#submit)");
+    const sibling = warnings.filter((w) =>
+      /Sibling combinator/.test(w.message),
+    );
+    assert.equal(sibling.length, 1);
+  });
+
+  it("warns on a context pseudo nested inside :where()", () => {
+    const warnings = warningsFor("input#email:where(:lang(en))");
+    const context = warnings.filter((w) =>
+      /Context-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(context.length, 1);
+  });
+
+  it("errors on a pseudo-element nested inside :not()", () => {
+    const errors = errorsFor("input#email:not(::placeholder)");
+    const pseudoEl = errors.filter((e) => /Pseudo-element/.test(e.message));
+    assert.equal(pseudoEl.length, 1);
+  });
+
+  it("errors on a namespaced token nested inside :not()", () => {
+    const errors = errorsFor("input#email:not(svg|rect)");
+    const ns = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(ns.length, 1);
+  });
+
+  it("does not flag a bare element wrapped in :not() as a bare element error", () => {
+    // :not(input) is semantically "not an input", not a target; our target-
+    // identity checks (bare element, class-only, ID-only) stay at top level.
+    const errors = errorsFor("div#wrapper:not(input)");
+    const bareElementErrors = errors.filter((e) =>
+      /Bare element selector/.test(e.message),
+    );
+    assert.equal(bareElementErrors.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Errors: root / shadow-root pseudo-classes
 // ---------------------------------------------------------------------------
 
@@ -737,6 +800,34 @@ describe("duplicate selectors", () => {
     const { warnings } = lintMapData(data);
     const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
     assert.equal(dupes.length, 0);
+  });
+
+  it("reports the duplicate at its real index when a sequence is interleaved", () => {
+    // Original array: [string, [sequence], duplicate-of-first-string]
+    // The duplicate lives at index 2 in the author's file, even though
+    // a non-string sits between the two duplicated strings.
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: {
+                username: [
+                  "input#user",
+                  ["input#otp-0", "input#otp-1"],
+                  "input#user",
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { warnings } = lintMapData(data);
+    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    assert.equal(dupes.length, 1);
+    assert.match(dupes[0].location, /\[2\]$/);
   });
 });
 

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -504,6 +504,118 @@ describe("state-dependent pseudo-classes", () => {
     );
     assert.equal(stateWarnings.length, 0);
   });
+
+  it("warns on :modal", () => {
+    const warnings = warningsFor("dialog#confirm:modal");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :open", () => {
+    const warnings = warningsFor("details#faq:open");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :popover-open", () => {
+    const warnings = warningsFor("div#menu:popover-open");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :fullscreen", () => {
+    const warnings = warningsFor("video#player:fullscreen");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: root / shadow-root pseudo-classes
+// ---------------------------------------------------------------------------
+
+describe("root / shadow-root pseudo-classes", () => {
+  it("reports an error for :host", () => {
+    const errors = errorsFor(":host");
+    const rootErrors = errors.filter((e) =>
+      /Root-context pseudo-class/.test(e.message),
+    );
+    assert.equal(rootErrors.length, 1);
+    assert.match(rootErrors[0].message, /:host/);
+  });
+
+  it("reports an error for :host() with an argument", () => {
+    const errors = errorsFor(":host(.login)");
+    const rootErrors = errors.filter((e) =>
+      /Root-context pseudo-class/.test(e.message),
+    );
+    assert.equal(rootErrors.length, 1);
+  });
+
+  it("reports an error for :host-context()", () => {
+    const errors = errorsFor(":host-context(main)");
+    const rootErrors = errors.filter((e) =>
+      /Root-context pseudo-class/.test(e.message),
+    );
+    assert.equal(rootErrors.length, 1);
+  });
+
+  it("reports an error for :root", () => {
+    const errors = errorsFor(":root input#email");
+    const rootErrors = errors.filter((e) =>
+      /Root-context pseudo-class/.test(e.message),
+    );
+    assert.equal(rootErrors.length, 1);
+    assert.match(rootErrors[0].message, /:root/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: context-dependent pseudo-classes
+// ---------------------------------------------------------------------------
+
+describe("context-dependent pseudo-classes", () => {
+  it("warns on :scope", () => {
+    const warnings = warningsFor(":scope > input#email");
+    const ctxWarnings = warnings.filter((w) =>
+      /Context-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(ctxWarnings.length, 1);
+    assert.match(ctxWarnings[0].message, /:scope/);
+  });
+
+  it("warns on :lang()", () => {
+    const warnings = warningsFor("input#email:lang(en)");
+    const ctxWarnings = warnings.filter((w) =>
+      /Context-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(ctxWarnings.length, 1);
+    assert.match(ctxWarnings[0].message, /:lang/);
+  });
+
+  it("warns on :dir()", () => {
+    const warnings = warningsFor("input#email:dir(ltr)");
+    const ctxWarnings = warnings.filter((w) =>
+      /Context-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(ctxWarnings.length, 1);
+  });
+
+  it("warns on :defined", () => {
+    const warnings = warningsFor("custom-input#email:defined");
+    const ctxWarnings = warnings.filter((w) =>
+      /Context-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(ctxWarnings.length, 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -1,0 +1,582 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  lintSelector,
+  lintMapData,
+  formatLocation,
+} from "./lint-selectors.mjs";
+
+// Shorthand: build a minimal location object for lintSelector calls
+function loc(overrides = {}) {
+  return {
+    host: "example.com",
+    category: "account-login",
+    kind: "fields",
+    key: "username",
+    selectorIndex: 0,
+    ...overrides,
+  };
+}
+
+// Helpers to pull just error/warning counts from a lintSelector result
+function errorsFor(selector, location) {
+  return lintSelector(selector, loc(location)).errors;
+}
+function warningsFor(selector, location) {
+  return lintSelector(selector, loc(location)).warnings;
+}
+
+// ---------------------------------------------------------------------------
+// formatLocation
+// ---------------------------------------------------------------------------
+
+describe("formatLocation", () => {
+  it("formats a host-level field location", () => {
+    const result = formatLocation({
+      host: "example.com",
+      category: "account-login",
+      kind: "fields",
+      key: "username",
+      selectorIndex: 0,
+    });
+    assert.equal(
+      result,
+      "example.com > [account-login] > fields.username > [0]",
+    );
+  });
+
+  it("includes pathname when present", () => {
+    const result = formatLocation({
+      host: "example.com",
+      pathname: "/login",
+      category: "account-login",
+      kind: "fields",
+      key: "password",
+      selectorIndex: 1,
+    });
+    assert.equal(
+      result,
+      "example.com > /login > [account-login] > fields.password > [1]",
+    );
+  });
+
+  it("includes sequence index when present", () => {
+    const result = formatLocation({
+      host: "example.com",
+      category: "account-login",
+      kind: "fields",
+      key: "oneTimeCode",
+      selectorIndex: 0,
+      seqIndex: 3,
+    });
+    assert.equal(
+      result,
+      "example.com > [account-login] > fields.oneTimeCode > sequence[3] > [0]",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: invalid CSS syntax
+// ---------------------------------------------------------------------------
+
+describe("invalid CSS syntax", () => {
+  it("reports an error for an unterminated attribute selector", () => {
+    const errors = errorsFor("input[name=");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Invalid CSS syntax/);
+  });
+
+  it("reports an error for an empty string segment after >>>", () => {
+    // "input#x >>> " — right side is empty, caught by boundary check first
+    // But "input#x >>> [" — right side is malformed CSS
+    const errors = errorsFor("input#x >>> input[");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Invalid CSS syntax/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: universal selector
+// ---------------------------------------------------------------------------
+
+describe("universal selector", () => {
+  it("reports an error for bare *", () => {
+    const errors = errorsFor("*");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Universal selector/);
+  });
+
+  it("reports an error for * with a qualifier", () => {
+    const errors = errorsFor("*[data-role='field']");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Universal selector/);
+  });
+
+  it("reports an error for * in a descendant chain", () => {
+    const errors = errorsFor("form#login > *");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Universal selector/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: bare element selector
+// ---------------------------------------------------------------------------
+
+describe("bare element selector", () => {
+  it("reports an error for a bare tag", () => {
+    const errors = errorsFor("input");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+  });
+
+  it("reports an error for a bare tag as the target of a descendant chain", () => {
+    const errors = errorsFor("form#login > input");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+  });
+
+  it("does not flag an element with an ID", () => {
+    assert.equal(errorsFor("input#email").length, 0);
+  });
+
+  it("does not flag an element with a class", () => {
+    assert.equal(errorsFor("input.username").length, 0);
+  });
+
+  it("does not flag an element with an attribute", () => {
+    assert.equal(errorsFor("input[name='user']").length, 0);
+  });
+
+  it("does not flag an element with a pseudo-class", () => {
+    // Pseudo-classes qualify the element (may trigger a positional warning
+    // separately, but not a bare-element error)
+    assert.equal(errorsFor("input:first-child").length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: class-only selector
+// ---------------------------------------------------------------------------
+
+describe("class-only selector", () => {
+  it("reports an error for a single class", () => {
+    const errors = errorsFor(".submit");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Class-only selector/);
+  });
+
+  it("reports an error for multiple classes with no element", () => {
+    const errors = errorsFor(".btn.primary");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Class-only selector/);
+  });
+
+  it("reports an error for a class-only target in a descendant chain", () => {
+    const errors = errorsFor("form#login > .submit");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Class-only selector/);
+  });
+
+  it("does not flag a class with an element qualifier", () => {
+    assert.equal(errorsFor("button.submit").length, 0);
+  });
+
+  it("does not flag a class with an attribute qualifier", () => {
+    assert.equal(errorsFor(".submit[type='submit']").length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: boundary combinator (>>>) structure
+// ---------------------------------------------------------------------------
+
+describe("boundary combinator (>>>) structure", () => {
+  it("reports an error when >>> starts the selector", () => {
+    const errors = errorsFor(">>> input#field");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /starts with/);
+  });
+
+  it("reports an error when >>> ends the selector", () => {
+    const errors = errorsFor("iframe#frame >>>");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /ends with/);
+  });
+
+  it("does not flag valid >>> usage", () => {
+    assert.equal(errorsFor("iframe#frame >>> input#field").length, 0);
+  });
+
+  it("does not flag chained >>> usage", () => {
+    assert.equal(
+      errorsFor("iframe#outer >>> div#shadow >>> input#field").length,
+      0,
+    );
+  });
+
+  it("lints each segment independently", () => {
+    // Left side is fine, right side is a bare element
+    const errors = errorsFor("iframe#frame >>> input");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: deep nesting
+// ---------------------------------------------------------------------------
+
+describe("deep nesting", () => {
+  it("warns when nesting exceeds 4 combinators", () => {
+    const warnings = warningsFor(
+      "div#a > div#b > div#c > div#d > div#e > input#f",
+    );
+    const nesting = warnings.filter((w) => /nesting/.test(w.message));
+    assert.equal(nesting.length, 1);
+    assert.match(nesting[0].message, /5 levels/);
+  });
+
+  it("does not warn at exactly 4 combinators", () => {
+    const warnings = warningsFor("div#a > div#b > div#c > div#d > input#e");
+    const nesting = warnings.filter((w) => /nesting/.test(w.message));
+    assert.equal(nesting.length, 0);
+  });
+
+  it("counts descendant combinators too", () => {
+    const warnings = warningsFor("div#a div#b div#c div#d div#e input#f");
+    const nesting = warnings.filter((w) => /nesting/.test(w.message));
+    assert.equal(nesting.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: positional pseudo-classes
+// ---------------------------------------------------------------------------
+
+describe("positional pseudo-classes", () => {
+  it("warns on :nth-child", () => {
+    const warnings = warningsFor("input:nth-child(2)");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /:nth-child/);
+  });
+
+  it("warns on :first-child", () => {
+    const warnings = warningsFor("input:first-child");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /:first-child/);
+  });
+
+  it("warns on :last-of-type", () => {
+    const warnings = warningsFor("input:last-of-type");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /:last-of-type/);
+  });
+
+  it("does not warn on non-positional pseudos", () => {
+    const warnings = warningsFor("input:focus");
+    assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: ID-only target
+// ---------------------------------------------------------------------------
+
+describe("ID-only target", () => {
+  it("warns on a single ID with no element type", () => {
+    const warnings = warningsFor("#email");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /ID-only selector/);
+  });
+
+  it("warns on an ID-only target at the end of a descendant chain", () => {
+    const warnings = warningsFor("form#login > #email");
+    const idOnly = warnings.filter((w) => /ID-only selector/.test(w.message));
+    assert.equal(idOnly.length, 1);
+  });
+
+  it("does not warn when an element type qualifies the ID", () => {
+    const warnings = warningsFor("input#email");
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not warn when a class qualifies the ID", () => {
+    const warnings = warningsFor("#email.primary");
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not warn when an attribute qualifies the ID", () => {
+    const warnings = warningsFor("#email[type='email']");
+    assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: selector length
+// ---------------------------------------------------------------------------
+
+describe("selector length", () => {
+  it("warns when selector exceeds 200 characters", () => {
+    const long = "div#" + "a".repeat(197);
+    assert.ok(long.length > 200);
+    const warnings = warningsFor(long);
+    const length = warnings.filter((w) => /characters long/.test(w.message));
+    assert.equal(length.length, 1);
+  });
+
+  it("does not warn at exactly 200 characters", () => {
+    const exact = "div#" + "a".repeat(196);
+    assert.equal(exact.length, 200);
+    const warnings = warningsFor(exact);
+    const length = warnings.filter((w) => /characters long/.test(w.message));
+    assert.equal(length.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: duplicates
+// ---------------------------------------------------------------------------
+
+describe("duplicate selectors", () => {
+  it("warns on duplicate selectors within a field's selector array", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: {
+                username: ["input#user", "input#user"],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { warnings } = lintMapData(data);
+    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    assert.equal(dupes.length, 1);
+  });
+
+  it("warns on duplicates within a selector sequence", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: {
+                oneTimeCode: [["input#otp-0", "input#otp-1", "input#otp-0"]],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { warnings } = lintMapData(data);
+    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    assert.equal(dupes.length, 1);
+  });
+
+  it("does not warn on the same selector in different fields", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: {
+                username: ["input#shared"],
+                email: ["input#shared"],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { warnings } = lintMapData(data);
+    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    assert.equal(dupes.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintMapData: structure traversal
+// ---------------------------------------------------------------------------
+
+describe("lintMapData traversal", () => {
+  it("returns no issues for valid selectors", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              container: ["form#login"],
+              fields: {
+                username: ["input#user"],
+                password: ["input#pass"],
+              },
+              actions: {
+                submit: ["button#go"],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("lints selectors under pathnames", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          pathnames: {
+            "/login": {
+              forms: [
+                {
+                  category: "account-login",
+                  fields: { username: ["input"] },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const { errors } = lintMapData(data);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+    assert.match(errors[0].location, /\/login/);
+  });
+
+  it("skips null host entries", () => {
+    const data = {
+      hosts: {
+        "example.com": null,
+      },
+    };
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("skips null pathname entries", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          pathnames: {
+            "/irrelevant": null,
+          },
+        },
+      },
+    };
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("lints container selectors", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              container: [".wrapper"],
+              fields: { username: ["input#user"] },
+            },
+          ],
+        },
+      },
+    };
+    const { errors } = lintMapData(data);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Class-only selector/);
+    assert.match(errors[0].location, /container\.container/);
+  });
+
+  it("lints action selectors", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: { username: ["input#user"] },
+              actions: { submit: ["button"] },
+            },
+          ],
+        },
+      },
+    };
+    const { errors } = lintMapData(data);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+    assert.match(errors[0].location, /actions\.submit/);
+  });
+
+  it("lints selector sequences in composite arrays", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: {
+                oneTimeCode: [["input", "input#otp-1"]],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { errors } = lintMapData(data);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Bare element selector/);
+    assert.match(errors[0].location, /sequence\[0\]/);
+  });
+
+  it("returns empty results when hosts is absent", () => {
+    const { errors, warnings } = lintMapData({});
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clean selectors: no false positives
+// ---------------------------------------------------------------------------
+
+describe("clean selectors produce no issues", () => {
+  const clean = [
+    "input#email",
+    "input[name='user']",
+    "input.email-field",
+    "button#submit-btn",
+    "button[type='submit']",
+    "form#login",
+    "form[action='/login']",
+    "div.container input#email",
+    "iframe#frame >>> input#field",
+    "iframe#outer >>> div#shadow-host >>> input#field",
+    "div#shadow-host >>> form#login > input#email",
+  ];
+
+  for (const selector of clean) {
+    it(`passes: ${selector}`, () => {
+      const { errors, warnings } = lintSelector(selector, loc());
+      assert.equal(errors.length, 0, `unexpected error: ${errors[0]?.message}`);
+      assert.equal(
+        warnings.length,
+        0,
+        `unexpected warning: ${warnings[0]?.message}`,
+      );
+    });
+  }
+});

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -274,9 +274,235 @@ describe("positional pseudo-classes", () => {
     assert.match(warnings[0].message, /:last-of-type/);
   });
 
-  it("does not warn on non-positional pseudos", () => {
-    const warnings = warningsFor("input:focus");
+  it("does not warn on functional pseudos", () => {
+    const warnings = warningsFor("input:not([type='hidden'])");
     assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: comma-separated selector list
+// ---------------------------------------------------------------------------
+
+describe("comma-separated selector list", () => {
+  it("reports an error for a top-level comma list", () => {
+    const errors = errorsFor("input#a, input#b");
+    const commaErrors = errors.filter((e) =>
+      /Comma-separated selector list/.test(e.message),
+    );
+    assert.equal(commaErrors.length, 1);
+  });
+
+  it("reports the comma error once regardless of how many alternatives", () => {
+    const errors = errorsFor("input#a, input#b, input#c");
+    const commaErrors = errors.filter((e) =>
+      /Comma-separated selector list/.test(e.message),
+    );
+    assert.equal(commaErrors.length, 1);
+  });
+
+  it("does not flag a comma inside an attribute value", () => {
+    const errors = errorsFor("input[data-tags='one,two']");
+    assert.equal(errors.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: pseudo-elements
+// ---------------------------------------------------------------------------
+
+describe("pseudo-elements", () => {
+  it("reports an error for ::before", () => {
+    const errors = errorsFor("input::before");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Pseudo-element/);
+    assert.match(errors[0].message, /::before/);
+  });
+
+  it("reports an error for ::placeholder", () => {
+    const errors = errorsFor("input::placeholder");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /::placeholder/);
+  });
+
+  it("reports an error for ::after", () => {
+    const errors = errorsFor("input::after");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /::after/);
+  });
+
+  it("reports a single pseudo-element error for a bare ::before", () => {
+    const errors = errorsFor("::before");
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /Pseudo-element/);
+    assert.match(errors[0].message, /::before/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: at-rule tokens
+// ---------------------------------------------------------------------------
+
+describe("at-rule tokens", () => {
+  it("reports an error for @media", () => {
+    const errors = errorsFor("@media screen");
+    const atRuleErrors = errors.filter((e) => /At-rule token/.test(e.message));
+    assert.equal(atRuleErrors.length, 1);
+    assert.match(atRuleErrors[0].message, /@media/);
+  });
+
+  it("reports an error for @keyframes", () => {
+    const errors = errorsFor("@keyframes fade");
+    const atRuleErrors = errors.filter((e) => /At-rule token/.test(e.message));
+    assert.equal(atRuleErrors.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: namespace separator
+// ---------------------------------------------------------------------------
+
+describe("namespace separator", () => {
+  it("reports an error for a named namespace prefix on a tag", () => {
+    const errors = errorsFor("svg|rect");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 1);
+    assert.match(nsErrors[0].message, /svg\|rect/);
+  });
+
+  it("reports an error for a redundant html| prefix", () => {
+    const errors = errorsFor("html|input");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 1);
+    assert.match(nsErrors[0].message, /html\|input/);
+  });
+
+  it("reports an error for the wildcard namespace (*|foo)", () => {
+    const errors = errorsFor("*|foo");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 1);
+    assert.match(nsErrors[0].message, /\*\|foo/);
+  });
+
+  it("reports an error for the empty namespace (|foo)", () => {
+    const errors = errorsFor("|foo");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 1);
+  });
+
+  it("reports an error for a namespaced attribute selector", () => {
+    const errors = errorsFor("input[html|lang]");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 1);
+    assert.match(nsErrors[0].message, /\[html\|lang\]/);
+  });
+
+  it("does not flag a selector without namespace prefixes", () => {
+    const errors = errorsFor("input[lang='en']");
+    const nsErrors = errors.filter((e) =>
+      /Namespace-qualified token/.test(e.message),
+    );
+    assert.equal(nsErrors.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: sibling combinators
+// ---------------------------------------------------------------------------
+
+describe("sibling combinators", () => {
+  it("warns on the adjacent sibling combinator (+)", () => {
+    const warnings = warningsFor("input#a + button#b");
+    const siblingWarnings = warnings.filter((w) =>
+      /Sibling combinator/.test(w.message),
+    );
+    assert.equal(siblingWarnings.length, 1);
+    assert.match(siblingWarnings[0].message, /\+/);
+  });
+
+  it("warns on the general sibling combinator (~)", () => {
+    const warnings = warningsFor("input#a ~ button#b");
+    const siblingWarnings = warnings.filter((w) =>
+      /Sibling combinator/.test(w.message),
+    );
+    assert.equal(siblingWarnings.length, 1);
+    assert.match(siblingWarnings[0].message, /~/);
+  });
+
+  it("does not warn on descendant or child combinators", () => {
+    const descendant = warningsFor("form#login input#email").filter((w) =>
+      /Sibling combinator/.test(w.message),
+    );
+    const child = warningsFor("form#login > input#email").filter((w) =>
+      /Sibling combinator/.test(w.message),
+    );
+    assert.equal(descendant.length, 0);
+    assert.equal(child.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: state-dependent pseudo-classes
+// ---------------------------------------------------------------------------
+
+describe("state-dependent pseudo-classes", () => {
+  it("warns on :focus", () => {
+    const warnings = warningsFor("input#email:focus");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+    assert.match(stateWarnings[0].message, /:focus/);
+  });
+
+  it("warns on :hover", () => {
+    const warnings = warningsFor("button#go:hover");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :checked", () => {
+    const warnings = warningsFor("input#agree:checked");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :required", () => {
+    const warnings = warningsFor("input#email:required");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("warns on :disabled", () => {
+    const warnings = warningsFor("input#email:disabled");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 1);
+  });
+
+  it("does not warn on positional pseudos (distinct warning family)", () => {
+    const warnings = warningsFor("input#email:first-child");
+    const stateWarnings = warnings.filter((w) =>
+      /State-dependent pseudo-class/.test(w.message),
+    );
+    assert.equal(stateWarnings.length, 0);
   });
 });
 

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -222,6 +222,38 @@ describe("boundary combinator (>>>) structure", () => {
     assert.equal(errors.length, 1);
     assert.match(errors[0].message, /Bare element selector/);
   });
+
+  it("continues processing past a leading-boundary misuse to aggregate more errors", () => {
+    // ">>>" at start is reported, AND the bare-element target on the right
+    // is also flagged in the same pass.
+    const errors = errorsFor(">>> input");
+    const startErr = errors.filter((e) => /starts with/.test(e.message));
+    const bareErr = errors.filter((e) =>
+      /Bare element selector/.test(e.message),
+    );
+    assert.equal(startErr.length, 1);
+    assert.equal(bareErr.length, 1);
+  });
+
+  it("continues processing past a trailing-boundary misuse to aggregate more errors", () => {
+    const errors = errorsFor("input >>>");
+    const endErr = errors.filter((e) => /ends with/.test(e.message));
+    const bareErr = errors.filter((e) =>
+      /Bare element selector/.test(e.message),
+    );
+    assert.equal(endErr.length, 1);
+    assert.equal(bareErr.length, 1);
+  });
+
+  it("reports both start and end boundary misuses when both are present", () => {
+    // ">>> input#x >>>" previously stopped at the start error; now both
+    // edge violations are surfaced in a single pass.
+    const errors = errorsFor(">>> input#x >>>");
+    const startErr = errors.filter((e) => /starts with/.test(e.message));
+    const endErr = errors.filter((e) => /ends with/.test(e.message));
+    assert.equal(startErr.length, 1);
+    assert.equal(endErr.length, 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -888,6 +888,54 @@ describe("lintMapData traversal", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Attribute matchers: explicitly supported
+// ---------------------------------------------------------------------------
+
+describe("attribute matchers are supported", () => {
+  const matchers = [
+    { pattern: "[attr]", selector: "[name]" },
+    { pattern: "[attr=value]", selector: "[name='username']" },
+    { pattern: "[attr*=value]", selector: "[name*='user']" },
+    { pattern: "[attr^=value]", selector: "[id^='field-']" },
+    { pattern: "[attr$=value]", selector: "[id$='-input']" },
+    { pattern: "[attr~=value]", selector: "[class~='primary']" },
+    { pattern: "[attr|=value]", selector: "[lang|='en']" },
+    { pattern: "[attr=value i]", selector: "[name='username' i]" },
+  ];
+
+  for (const { pattern, selector } of matchers) {
+    it(`allows ${pattern} matcher: ${selector}`, () => {
+      const { errors, warnings } = lintSelector(`input${selector}`, loc());
+      assert.equal(errors.length, 0, `unexpected error: ${errors[0]?.message}`);
+      assert.equal(
+        warnings.length,
+        0,
+        `unexpected warning: ${warnings[0]?.message}`,
+      );
+    });
+  }
+
+  it("allows attribute matchers as the sole qualifier on an element", () => {
+    const { errors, warnings } = lintSelector(
+      "input[autocomplete='new-password']",
+      loc(),
+    );
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("allows combining attribute matchers with other qualifiers", () => {
+    const { errors, warnings } = lintSelector(
+      // `required` attribute not to be confused with `:required` pseudo-class
+      "input#email[type^='email-'][required]",
+      loc(),
+    );
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Clean selectors: no false positives
 // ---------------------------------------------------------------------------
 

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -60,18 +60,18 @@ describe("formatLocation", () => {
     );
   });
 
-  it("includes sequence index when present", () => {
+  it("reads outside-in for a sequence location (composite position first, then inner position)", () => {
     const result = formatLocation({
       host: "example.com",
       category: "account-login",
       kind: "fields",
       key: "oneTimeCode",
-      selectorIndex: 0,
-      seqIndex: 3,
+      selectorIndex: 0, // composite position of the sequence
+      sequenceIndex: 3, // inner position within the sequence
     });
     assert.equal(
       result,
-      "example.com > [account-login] > fields.oneTimeCode > sequence[3] > [0]",
+      "example.com > [account-login] > fields.oneTimeCode > sequence[0] > [3]",
     );
   });
 });
@@ -957,7 +957,11 @@ describe("duplicate selectors", () => {
     assert.equal(dupes.length, 1);
   });
 
-  it("errors on duplicates within a selector sequence", () => {
+  it("does NOT flag duplicates within a selector sequence (reserved for split-value semantics)", () => {
+    // Inner sequences describe how a single value is split across inputs at
+    // one location. Duplicate entries are reserved for future "group these
+    // character positions into the same input" semantics (e.g., partial-
+    // value fields). Only the outer composite array dedupes.
     const data = {
       hosts: {
         "example.com": {
@@ -974,7 +978,7 @@ describe("duplicate selectors", () => {
     };
     const { errors } = lintMapData(data);
     const dupes = errors.filter((e) => /Duplicate/.test(e.message));
-    assert.equal(dupes.length, 1);
+    assert.equal(dupes.length, 0);
   });
 
   it("does not flag the same selector in different fields", () => {

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -715,6 +715,202 @@ describe("ID-only target", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Errors: empty-value substring / prefix / suffix matchers
+// ---------------------------------------------------------------------------
+
+describe("empty-value attribute matchers", () => {
+  it("errors on [attr*='']", () => {
+    const errors = errorsFor("input[name*='']");
+    const substring = errors.filter((e) =>
+      /substring\/prefix\/suffix operator/.test(e.message),
+    );
+    assert.equal(substring.length, 1);
+    assert.match(substring[0].message, /\[name\*=''\]/);
+  });
+
+  it("errors on [attr^='']", () => {
+    const errors = errorsFor("input[id^='']");
+    const substring = errors.filter((e) =>
+      /substring\/prefix\/suffix operator/.test(e.message),
+    );
+    assert.equal(substring.length, 1);
+    assert.match(substring[0].message, /\[id\^=''\]/);
+  });
+
+  it("errors on [attr$='']", () => {
+    const errors = errorsFor("input[id$='']");
+    const substring = errors.filter((e) =>
+      /substring\/prefix\/suffix operator/.test(e.message),
+    );
+    assert.equal(substring.length, 1);
+    assert.match(substring[0].message, /\[id\$=''\]/);
+  });
+
+  it("does not flag a non-empty substring match", () => {
+    const { errors, warnings } = lintSelector("input[name*='user']", loc());
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not flag the existence matcher [attr]", () => {
+    const { errors, warnings } = lintSelector("input[name]", loc());
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not flag exact-match empty value [attr='']", () => {
+    // `[name='']` has a specific meaning (matches when attr value is
+    // literally the empty string) — not the same as "[name]".
+    const { errors, warnings } = lintSelector("input[name='']", loc());
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not flag when nested inside :not()", () => {
+    // :not([class*='']) is a valid construct meaning "without a class attr";
+    // assume the author knows what they're doing.
+    const errors = errorsFor("input#email:not([class*=''])");
+    const substring = errors.filter((e) =>
+      /substring\/prefix\/suffix operator/.test(e.message),
+    );
+    assert.equal(substring.length, 0);
+  });
+
+  it("errors on [attr~=''] as an always-false matcher", () => {
+    const errors = errorsFor("input[class~='']");
+    const alwaysFalse = errors.filter((e) =>
+      /matches no elements/.test(e.message),
+    );
+    assert.equal(alwaysFalse.length, 1);
+    assert.match(alwaysFalse[0].message, /\[class~=''\]/);
+  });
+
+  it("does not flag a non-empty word match with ~=", () => {
+    const { errors, warnings } = lintSelector("input[class~='primary']", loc());
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors: empty-or-whitespace-only selector
+// ---------------------------------------------------------------------------
+
+describe("empty-or-whitespace-only selector", () => {
+  it("errors on a whitespace-only selector", () => {
+    const errors = errorsFor("   ");
+    const empty = errors.filter((e) =>
+      /Selector is empty or contains only whitespace/.test(e.message),
+    );
+    assert.equal(empty.length, 1);
+  });
+
+  it("errors on a tab-only selector", () => {
+    const errors = errorsFor("\t");
+    const empty = errors.filter((e) =>
+      /Selector is empty or contains only whitespace/.test(e.message),
+    );
+    assert.equal(empty.length, 1);
+  });
+
+  it("errors on an empty segment between >>> combinators", () => {
+    // ">>> input" is caught by the boundary-at-start check. A middle empty
+    // segment between two >>> combinators falls through to the
+    // parsedSelectors.length === 0 branch.
+    const errors = errorsFor("input#a >>>    >>> input#b");
+    const emptySegment = errors.filter((e) =>
+      /Segment between ">>>"/.test(e.message),
+    );
+    assert.equal(emptySegment.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: container selector targets a non-container tag
+// ---------------------------------------------------------------------------
+
+describe("container non-container target", () => {
+  function containerLoc() {
+    return {
+      host: "example.com",
+      category: "account-login",
+      kind: "container",
+      key: "container",
+      selectorIndex: 0,
+    };
+  }
+
+  it("warns when a container targets <input>", () => {
+    const { warnings } = lintSelector("input#email", containerLoc());
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 1);
+    assert.match(misuse[0].message, /<input>/);
+  });
+
+  it("warns when a container targets <button>", () => {
+    const { warnings } = lintSelector("button#submit", containerLoc());
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 1);
+  });
+
+  it("warns when a container targets <option>", () => {
+    const { warnings } = lintSelector("option#choice", containerLoc());
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 1);
+  });
+
+  it("does not warn when a container targets a wrapping element", () => {
+    for (const ok of ["form#login", "div#login-wrapper", "section#auth"]) {
+      const { warnings } = lintSelector(ok, containerLoc());
+      const misuse = warnings.filter((w) =>
+        /Container selector targets/.test(w.message),
+      );
+      assert.equal(misuse.length, 0, `unexpected misuse warning for: ${ok}`);
+    }
+  });
+
+  it("does not warn on the same selector under fields.*", () => {
+    const { warnings } = lintSelector("input#email", loc());
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 0);
+  });
+
+  it("only inspects the final >>> segment", () => {
+    // Left side is an iframe (not in the denylist); final target is form.
+    // The intermediate <input> in a chain like this wouldn't happen in
+    // practice; this just confirms we don't falsely flag intermediates.
+    const { warnings } = lintSelector(
+      "iframe#auth-frame >>> form#login",
+      containerLoc(),
+    );
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 0);
+  });
+
+  it("does flag when the final >>> segment targets a non-container", () => {
+    const { warnings } = lintSelector(
+      "iframe#auth-frame >>> input#email",
+      containerLoc(),
+    );
+    const misuse = warnings.filter((w) =>
+      /Container selector targets/.test(w.message),
+    );
+    assert.equal(misuse.length, 1);
+    assert.match(misuse[0].message, /<input>/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Warnings: selector length
 // ---------------------------------------------------------------------------
 
@@ -737,11 +933,11 @@ describe("selector length", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Warnings: duplicates
+// Errors: duplicates
 // ---------------------------------------------------------------------------
 
 describe("duplicate selectors", () => {
-  it("warns on duplicate selectors within a field's selector array", () => {
+  it("errors on duplicate selectors within a field's selector array", () => {
     const data = {
       hosts: {
         "example.com": {
@@ -756,12 +952,12 @@ describe("duplicate selectors", () => {
         },
       },
     };
-    const { warnings } = lintMapData(data);
-    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    const { errors } = lintMapData(data);
+    const dupes = errors.filter((e) => /Duplicate/.test(e.message));
     assert.equal(dupes.length, 1);
   });
 
-  it("warns on duplicates within a selector sequence", () => {
+  it("errors on duplicates within a selector sequence", () => {
     const data = {
       hosts: {
         "example.com": {
@@ -776,12 +972,12 @@ describe("duplicate selectors", () => {
         },
       },
     };
-    const { warnings } = lintMapData(data);
-    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    const { errors } = lintMapData(data);
+    const dupes = errors.filter((e) => /Duplicate/.test(e.message));
     assert.equal(dupes.length, 1);
   });
 
-  it("does not warn on the same selector in different fields", () => {
+  it("does not flag the same selector in different fields", () => {
     const data = {
       hosts: {
         "example.com": {
@@ -797,8 +993,10 @@ describe("duplicate selectors", () => {
         },
       },
     };
-    const { warnings } = lintMapData(data);
-    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    const { errors, warnings } = lintMapData(data);
+    const dupes = [...errors, ...warnings].filter((w) =>
+      /Duplicate/.test(w.message),
+    );
     assert.equal(dupes.length, 0);
   });
 
@@ -824,8 +1022,8 @@ describe("duplicate selectors", () => {
         },
       },
     };
-    const { warnings } = lintMapData(data);
-    const dupes = warnings.filter((w) => /Duplicate/.test(w.message));
+    const { errors } = lintMapData(data);
+    const dupes = errors.filter((e) => /Duplicate/.test(e.message));
     assert.equal(dupes.length, 1);
     assert.match(dupes[0].location, /\[2\]$/);
   });

--- a/scripts/lint-selectors.mjs
+++ b/scripts/lint-selectors.mjs
@@ -1,0 +1,82 @@
+import { lintMapData } from "./lib/lint-selectors.mjs";
+import stripJsonComments from "strip-json-comments";
+import { readFileSync } from "fs";
+import { glob } from "node:fs/promises";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+let files = process.argv.slice(2).filter((f) => !f.endsWith(".schema.json"));
+
+if (files.length === 0) {
+  const matches = glob("maps/forms/*.jsonc");
+  for await (const match of matches) {
+    files.push(match);
+  }
+}
+
+if (files.length === 0) {
+  console.log("No map files to lint.");
+  process.exit(0);
+}
+
+let totalErrors = 0;
+let totalWarnings = 0;
+
+for (const file of files) {
+  let data;
+  try {
+    data = JSON.parse(stripJsonComments(readFileSync(file, "utf-8")));
+  } catch (e) {
+    console.error(red(`Failed to parse ${file}: ${e.message}`));
+    totalErrors++;
+    continue;
+  }
+
+  const { errors, warnings } = lintMapData(data);
+
+  if (errors.length === 0 && warnings.length === 0) {
+    console.log(green(`Selectors OK: ${file}`));
+    continue;
+  }
+
+  for (const w of warnings) {
+    console.warn(
+      yellow(`Warning: ${file} - ${w.location}\n`) +
+        dim(`  selector: ${w.selector}\n`) +
+        yellow(`  ${w.message}`),
+    );
+  }
+
+  for (const e of errors) {
+    console.error(
+      red(`Error: ${file} - ${e.location}\n`) +
+        dim(`  selector: ${e.selector}\n`) +
+        red(`  ${e.message}`),
+    );
+  }
+
+  totalErrors += errors.length;
+  totalWarnings += warnings.length;
+}
+
+if (totalWarnings > 0) {
+  console.warn(yellow(`\n${totalWarnings} selector warning(s)`));
+}
+
+if (totalErrors > 0) {
+  console.error(red(`${totalErrors} selector error(s)`));
+  process.exit(1);
+} else {
+  console.log(green("Selector linting passed."));
+}

--- a/scripts/lint-selectors.mjs
+++ b/scripts/lint-selectors.mjs
@@ -4,6 +4,18 @@ import { readFileSync } from "fs";
 import { glob } from "node:fs/promises";
 
 // ---------------------------------------------------------------------------
+// Environment configuration
+// ---------------------------------------------------------------------------
+
+// Emit GitHub Actions workflow commands (inline PR annotations) only when
+// running inside Actions AND the repo variable ENABLE_SELECTOR_LINT_PR_FEEDBACK
+// is explicitly set to "true".
+const inGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const prFeedbackEnabled =
+  process.env.ENABLE_SELECTOR_LINT_PR_FEEDBACK === "true";
+const emitAnnotations = inGitHubActions && prFeedbackEnabled;
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -11,6 +23,83 @@ const red = (s) => `\x1b[31m${s}\x1b[0m`;
 const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
 const green = (s) => `\x1b[32m${s}\x1b[0m`;
 const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+/**
+ * Best-effort line-number lookup for a lint finding. Progressively narrows
+ * the search by walking the logical location (host, optional pathname,
+ * kind.key), then returns the line of the first occurrence of the selector
+ * within that scope. Returns null when any anchor or the selector can't be
+ * located; callers should fall back to the logical location in that case.
+ */
+function findLineInSource(source, formattedLocation, selector) {
+  if (!selector) {
+    return null;
+  }
+
+  const parts = formattedLocation.split(" > ");
+  let position = 0;
+
+  // 1. Host is always the first segment.
+  position = source.indexOf(`"${parts[0]}":`);
+  if (position === -1) {
+    return null;
+  }
+
+  // 2. Optional pathname appears as the second segment when it starts with "/".
+  if (parts[1] && parts[1].startsWith("/")) {
+    const next = source.indexOf(`"${parts[1]}":`, position);
+    if (next === -1) {
+      return null;
+    }
+    position = next;
+  }
+
+  // 3. kind.key (e.g., "fields.username", "actions.submit", "container.container")
+  //    narrows the search to the specific array that holds the selector.
+  const kindKey = parts.find((p) => /^(fields|actions|container)\./.test(p));
+  if (kindKey) {
+    const key = kindKey.split(".")[1];
+    const next = source.indexOf(`"${key}":`, position);
+    if (next !== -1) {
+      position = next;
+    }
+    // If the key isn't found we fall back to the host-scoped search rather
+    // than bailing; the selector anchor below will still point somewhere
+    // reasonable.
+  }
+
+  // 4. Find the first occurrence of the selector within the scope. For
+  //    duplicate-selector errors, either occurrence is in the same cluster
+  //    and points the author at the relevant area.
+  position = source.indexOf(JSON.stringify(selector), position);
+  if (position === -1) {
+    return null;
+  }
+
+  return source.slice(0, position).split("\n").length;
+}
+
+/**
+ * Escape a message for a GitHub Actions workflow command.
+ * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#about-workflow-commands
+ */
+function ghEscape(value) {
+  return String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+function ghWorkflowCommand(severity, file, codeLine, title, message) {
+  const parts = [`file=${ghEscape(file)}`];
+  if (codeLine != null) {
+    parts.push(`line=${codeLine}`);
+  }
+  if (title) {
+    parts.push(`title=${ghEscape(title)}`);
+  }
+  return `::${severity} ${parts.join(",")}::${ghEscape(message)}`;
+}
 
 // ---------------------------------------------------------------------------
 // Main
@@ -34,9 +123,24 @@ let totalErrors = 0;
 let totalWarnings = 0;
 
 for (const file of files) {
+  let source;
+  try {
+    source = readFileSync(file, "utf-8");
+  } catch (e) {
+    console.error(red(`Failed to read ${file}: ${e.message}`));
+    totalErrors++;
+    continue;
+  }
+
+  // `strip-json-comments` preserves line counts (replaces comments with
+  // whitespace), so line numbers from the stripped text match the original
+  // file. Search in the stripped version so commented-out selectors don't
+  // produce false matches.
+  const stripped = stripJsonComments(source);
+
   let data;
   try {
-    data = JSON.parse(stripJsonComments(readFileSync(file, "utf-8")));
+    data = JSON.parse(stripped);
   } catch (e) {
     console.error(red(`Failed to parse ${file}: ${e.message}`));
     totalErrors++;
@@ -51,19 +155,45 @@ for (const file of files) {
   }
 
   for (const w of warnings) {
+    const codeLine = findLineInSource(stripped, w.location, w.selector);
+    const suffix = codeLine != null ? ` (line ${codeLine})` : "";
     console.warn(
-      yellow(`Warning: ${file} - ${w.location}\n`) +
+      yellow(`Warning: ${file} - ${w.location}${suffix}\n`) +
         dim(`  selector: ${w.selector}\n`) +
-        yellow(`  ${w.message}`),
+        yellow(`  ${w.message}\n`),
     );
+    if (emitAnnotations) {
+      console.log(
+        ghWorkflowCommand(
+          "warning",
+          file,
+          codeLine,
+          `Selector lint: ${w.location}`,
+          w.message,
+        ),
+      );
+    }
   }
 
   for (const e of errors) {
+    const codeLine = findLineInSource(stripped, e.location, e.selector);
+    const suffix = codeLine != null ? ` (line ${codeLine})` : "";
     console.error(
-      red(`Error: ${file} - ${e.location}\n`) +
+      red(`Error: ${file} - ${e.location}${suffix}\n`) +
         dim(`  selector: ${e.selector}\n`) +
-        red(`  ${e.message}`),
+        red(`  ${e.message}\n`),
     );
+    if (emitAnnotations) {
+      console.log(
+        ghWorkflowCommand(
+          "error",
+          file,
+          codeLine,
+          `Selector lint: ${e.location}`,
+          e.message,
+        ),
+      );
+    }
   }
 
   totalErrors += errors.length;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33102](https://bitwarden.atlassian.net/browse/PM-33102)

## 📔 Objective

Add automated selector-quality checks for the forms map that run in PR CI and on local pre-commit, addressing vague selectors (mis-targeting on pages with varying node order) and rigid selectors (breaking when upper tree changes).

The linting rules informed by:
- some selector features being irrelevant to form maps, despite being otherwise valid
- human authoring concerns (e.g. copy-paste errors)
- expectations of variability of technical proficiencies from technical maintainers/contributions to the project
- [specificity calculations](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Specificity#how_is_specificity_calculated), where scores with only one column satisfied are considered insufficient:

  Specificity (ID, class/attr/pseudo, type) | Example | Coverage
  -- | -- | --
  (0,0,0) | `*` | Error — universal selector
  (0,0,1) | `input` | Error — bare element
  (0,1,0) | `.submit` | Error — class-only
  (1,0,0) | `#email` | Warning — ID-only (prefer input#email for clarity) 

Given these concerns, warning/error feedback is focused on remediation guidance.

The checks will also do best-effort line annotation for the PR when the `ENABLE_SELECTOR_LINT_PR_FEEDBACK` env variable is enabled.

**Example Output**: https://github.com/bitwarden/map-the-web/actions/runs/24740514438/job/72378658684?pr=9
**Inline guidance** (run against this PR):
<img width="939" height="1077" alt="Screenshot 2026-04-21 at 2 54 39 PM" src="https://github.com/user-attachments/assets/7c59df4e-5c2e-420a-9fd8-13c7ea074d75" />

[PM-33102]: https://bitwarden.atlassian.net/browse/PM-33102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ