### PR TITLE
[PM-36620] Add linting rule for password vs newPassword usage

### DIFF
--- a/maps/forms/README.md
+++ b/maps/forms/README.md
@@ -354,7 +354,7 @@ A page may have more than one logical form. Each gets its own entry in the
       "category": "account-creation",
       "fields": {
         "username": ["#register-email"],
-        "password": ["#register-pass"]
+        "newPassword": ["#register-pass"]
       }
     }
   ]

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -776,6 +776,7 @@ export function lintMapData(data) {
 function lintForms(forms, context, errors, warnings) {
   for (const form of forms) {
     const category = form.category || "unknown";
+    lintPasswordFieldSemantics(form, category, context, errors);
 
     // Container selectors
     if (form.container) {
@@ -886,5 +887,50 @@ function checkDuplicates(selectors, context, errors) {
       });
     }
     seen.add(s);
+  }
+}
+
+/** Reject password key mismatches for login vs creation forms. */
+function lintPasswordFieldSemantics(form, category, context, errors) {
+  const fields = form.fields;
+  if (!fields) {
+    return;
+  }
+
+  const headSelector = (selectors) =>
+    Array.isArray(selectors) && typeof selectors[0] === "string"
+      ? selectors[0]
+      : null;
+
+  if (category === "account-login" && Object.hasOwn(fields, "newPassword")) {
+    errors.push({
+      location: formatLocation({
+        ...context,
+        category,
+        kind: "fields",
+        key: "newPassword",
+        selectorIndex: 0,
+      }),
+      selector: headSelector(fields.newPassword),
+      message:
+        `Field key "newPassword" should not be used for ${category} forms. ` +
+        `Use "password" for login password fields.`,
+    });
+  }
+
+  if (category === "account-creation" && Object.hasOwn(fields, "password")) {
+    errors.push({
+      location: formatLocation({
+        ...context,
+        category,
+        kind: "fields",
+        key: "password",
+        selectorIndex: 0,
+      }),
+      selector: headSelector(fields.password),
+      message:
+        `Field key "password" should not be used for ${category} forms. ` +
+        `Use "newPassword" for new or confirmation password fields.`,
+    });
   }
 }

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -1291,3 +1291,63 @@ describe("clean selectors produce no issues", () => {
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// lintMapData: password field semantics
+// ---------------------------------------------------------------------------
+
+describe("password field semantics", () => {
+  function lintExampleForm(fields, category) {
+    return lintMapData({
+      hosts: {
+        "example.com": {
+          forms: [{ category, fields }],
+        },
+      },
+    });
+  }
+
+  function semanticErrors(fields, category, pattern) {
+    return lintExampleForm(fields, category).errors.filter((e) =>
+      pattern.test(e.message),
+    );
+  }
+
+  it("allows account-creation with newPassword", () => {
+    const { errors } = lintExampleForm(
+      { email: ["input#email"], newPassword: ["input#pw"] },
+      "account-creation",
+    );
+    assert.equal(errors.length, 0);
+  });
+
+  it("allows account-login with password", () => {
+    const { errors } = lintExampleForm(
+      { username: ["input#user"], password: ["input#pw"] },
+      "account-login",
+    );
+    assert.equal(errors.length, 0);
+  });
+
+  it("errors when account-creation uses password instead of newPassword", () => {
+    assert.equal(
+      semanticErrors(
+        { email: ["input#email"], password: ["input#password"] },
+        "account-creation",
+        /should not be used for account-creation/,
+      ).length,
+      1,
+    );
+  });
+
+  it("errors when account-login uses newPassword instead of password", () => {
+    assert.equal(
+      semanticErrors(
+        { username: ["input#user"], newPassword: ["input#pass"] },
+        "account-login",
+        /should not be used for account-login/,
+      ).length,
+      1,
+    );
+  });
+});


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36620
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
 add linting rule and test for newPassword vs password in order to avoid incorrect usage

