### PR TITLE
[PM-38221] Additional guidance and linting

### DIFF
--- a/.remarkrc.json
+++ b/.remarkrc.json
@@ -5,7 +5,9 @@
     "remark-preset-lint-consistent",
     "remark-preset-lint-recommended",
     ["remark-lint-no-heading-punctuation", false],
-    "remark-lint-no-trailing-spaces"
+    "remark-lint-no-trailing-spaces",
+    ["remark-lint-emphasis-marker", "_"],
+    ["remark-lint-strong-marker", "*"]
   ],
   "settings": {
     "bullet": "-",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ With the aforementioned goals and intent in mind, Maps should:
 - only describe websites where a given concern is not otherwise accessible
 - only capture shared web concerns; local network configurations are out of
   scope
-- be as specific as possible while avoiding "brittle" descriptions
+- be as specific as possible while avoiding unrelated concerns
 - be removed from a given Map if a site becomes navigable by other standard
   means for those concerns
 - avoid staleness and be kept up-to-date

--- a/maps/forms/README.md
+++ b/maps/forms/README.md
@@ -33,6 +33,7 @@ may or may not utilize the HTML `form` tag. See the project
   - [Forms](#forms)
     - [Multiple Forms](#multiple-forms)
     - [Category](#category)
+  - [Selector Philosophy](#selector-philosophy)
   - [Container](#container)
   - [Fields](#fields)
     - [Field Keys](#field-keys)
@@ -355,15 +356,15 @@ A page may have more than one logical form. Each gets its own entry in the
     {
       "category": "account-login",
       "fields": {
-        "username": ["#login-email"],
-        "password": ["#login-pass"]
+        "username": ["input#login-email"],
+        "password": ["input#login-pass"]
       }
     },
     {
       "category": "account-creation",
       "fields": {
-        "username": ["#register-email"],
-        "newPassword": ["#register-pass"]
+        "username": ["input#register-email"],
+        "newPassword": ["input#register-pass"]
       }
     }
   ]
@@ -387,6 +388,31 @@ relevant to their concerns).
 | `payment-card`     | Credit/debit card payment                          |
 | `search`           | Search form                                        |
 | `signup`           | Newsletter, sweepstakes, unsubscribe, or general contact signup (not account creation) |
+
+## Selector Philosophy
+
+Forms Map selectors are not stylesheet selectors. A stylesheet selector aims
+for _resilience_; it should keep matching the same conceptual element as the
+page evolves, so the styling survives. A map selector aims for the opposite:
+it is a curated record of what a known target (that is, the full node
+hierarchy described by the selector, not just the leaf) looks like today. Tag
+drift, attribute renaming, or structural change of the target is the kind of
+signal that should trigger a review rather than be silently absorbed.
+
+This inverts the conventional "make selectors resilient" advice: Forms Map
+selectors should be brittle by design. If a page's login `<div role="form">`
+becomes an actual `<form>`, or an `<input>` is replaced by a custom element,
+the selector _should_ break; both as a prompt to a Map Author to re-verify
+that the new target is still the right one and as a guard against a consuming
+application interacting with something the Map was never authored to describe.
+
+In practice, this means every selector segment should include a tag anchor.
+Add the tag (e.g. `input[name='username']`, `button.submit#go`,
+`input#user[type='email']`) so the selector breaks if the element type ever
+changes. The same rule applies independently to each segment of a
+boundary-crossing selector, so `iframe#login-frame >>> input[name='username']`
+satisfies it on both sides; `#login-frame >>> input[name='username']` does
+not.
 
 ## Container
 
@@ -646,7 +672,7 @@ host into its shadow root's content
 
 ```json
 {
-  "username": ["#host-element >>> form > input[name='username']"]
+  "username": ["div#host-element >>> form > input[name='username']"]
 }
 ```
 
@@ -654,7 +680,7 @@ For nested shadow roots:
 
 ```json
 {
-  "username": ["#outer-host >>> #inner-host >>> input[name='user']"]
+  "username": ["div#outer-host >>> div#inner-host >>> input[name='user']"]
 }
 ```
 
@@ -746,9 +772,10 @@ The distinction between "irrelevant" and "no information" is important. An
    Consumers are responsible for their own timing strategy (e.g. polling,
    MutationObserver) when elements are not immediately present.
 
-3. **Be specific.** Prefer ID-based or attribute-based selectors over positional
-   ones (`:nth-child`, tag-only). Specific selectors are more resilient to page
-   layout changes.
+3. **Be specific.** Prefer tag selectors with an accompanying ID or attribute
+   over positional pseudos (e.g. `:nth-child`) or bare tag (e.g. `div`). Classes
+   should be non-preferred in selector descriptions as they typically represent
+   broad concerns.
 
 4. **Use `>>>` only when necessary.** Only use boundary-crossing selectors when
    the target element is actually inside a shadow root or iframe.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:md": "remark . --frail --quiet",
     "lint:selectors": "node scripts/lint-selectors.mjs",
     "validate": "node scripts/validate-schemas.mjs",
-    "check": "npm run prettier && npm run lint:md && npm run validate && npm run lint:selectors",
+    "check": "npm run prettier && npm run lint:md && npm run validate && npm run lint:selectors && npm test",
     "test": "node --test scripts/**/*.test.mjs",
     "build": "node scripts/build.mjs",
     "build:clean": "rm -rf dist && node scripts/build.mjs"

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -335,6 +335,34 @@ function findNonContainerTarget(tokens) {
 }
 
 /**
+ * Determine whether the target compound anchors on a form: either a `form`
+ * tag or an attribute matcher on `role` whose value mentions "form" (e.g.
+ * `[role='form']`, `[role*='form']`, `[role~='form']`).
+ *
+ * Looks at the top-level final compound only; does not descend into
+ * functional pseudos (`:is(form)`, `:where(...)`). Those patterns won't
+ * satisfy the check, which is a deliberate simplification — the common
+ * authoring patterns we want to accept are a `form` tag or an explicit role.
+ */
+function hasFormAnchor(tokens) {
+  const compound = getLastCompound(tokens);
+  for (const t of compound) {
+    if (t.type === "tag" && t.name === "form") {
+      return true;
+    }
+    if (
+      t.type === "attribute" &&
+      t.name === "role" &&
+      typeof t.value === "string" &&
+      /form/i.test(t.value)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Find attribute matchers that use an operator equivalent to existence check
  * when the value is empty (*=, ^=, $= with empty value).
  */
@@ -766,17 +794,29 @@ export function lintSelector(raw, location) {
         });
       }
 
-      // Container-misuse warning: only when linting a `container` entry,
+      // Container-specific checks: only when linting a `container` entry,
       // and only on the final segment (the actual target after any >>>).
+      // When `container` is omitted entirely, this branch is never reached.
       if (location.kind === "container" && isFinalSegment) {
         const badTag = findNonContainerTarget(tokens);
         if (badTag) {
+          // Pointing at a leaf control is the actionable signal here; a
+          // missing form anchor would be redundant noise on top of it.
           warnings.push({
             location: formattedLocation,
             selector: raw,
             message:
               `Container selector targets <${badTag}>, which is not typically a wrapping element. ` +
               `If this selector identifies a form field, move it under \`fields\`; if it identifies an action, move it under \`actions\`.`,
+          });
+        } else if (!hasFormAnchor(tokens)) {
+          warnings.push({
+            location: formattedLocation,
+            selector: raw,
+            message:
+              `Container selector "${segment}" does not anchor on a form element ` +
+              `(\`form\` tag or \`[role='form']\`). ` +
+              `If no \`<form>\` or \`[role='form']\` exists, this warning may be ignored.`,
           });
         }
       }

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -210,6 +210,51 @@ function isIdOnly(tokens) {
 }
 
 /**
+ * Check whether the target compound establishes identity via id/class/
+ * attribute matchers but has no tag anchor. This is the general "missing
+ * element type" case: catches attribute-only (`[name='x']`), class+attribute
+ * (`.foo[name='x']`), id+attribute (`#x[name='y']`), class+id (`.foo#x`),
+ * and other mixes that omit the tag.
+ *
+ * Intentionally requires at least one identity-establishing non-tag token
+ * (id/class/attribute) before firing. Pure pseudo-class selectors are
+ * caught separately by `isPseudoOnly`.
+ */
+function lacksTagAnchor(tokens) {
+  const compound = getLastCompound(tokens);
+  if (compound.some((t) => t.type === "tag")) {
+    return false;
+  }
+  return compound.some((t) => t.type === "attribute");
+}
+
+/**
+ * Check whether the target compound consists only of pseudo-class
+ * constraints (`:hover`, `:not(input)`, `:has(form)`, etc.) with no
+ * identifying token at all.
+ *
+ * Pseudo-classes qualify a target — they describe state, negation, or
+ * structural relationships — but they do not identify one. A compound
+ * without a tag/id/class/attribute anchor isn't claiming what the target
+ * IS, only what it ISN'T (or what state it's in).
+ */
+function isPseudoOnly(tokens) {
+  const compound = getLastCompound(tokens);
+  if (compound.length === 0) {
+    return false;
+  }
+  if (
+    compound.some(
+      (t) =>
+        t.type === "tag" || t.type === "attribute" || t.type === "universal",
+    )
+  ) {
+    return false;
+  }
+  return compound.some((t) => t.type === "pseudo");
+}
+
+/**
  * Return the last compound selector (tokens after the final combinator).
  */
 function getLastCompound(tokens) {
@@ -231,8 +276,8 @@ function combinatorDepth(tokens) {
 
 /**
  * Walk a token list, yielding every token including those nested inside
- * functional pseudo-classes (e.g., :not(...), :is(...), :has(...)).
- * Pseudos with string .data (e.g., :lang("en")) are not descended into.
+ * functional pseudo-classes (e.g. :not(...), :is(...), :has(...)).
+ * Pseudos with string .data (e.g. :lang("en")) are not descended into.
  */
 function* walkTokens(tokens) {
   for (const t of tokens) {
@@ -308,7 +353,7 @@ function findAtRuleTags(tokens) {
 
 /**
  * Find namespace-qualified tokens and return readable renderings of each
- * (e.g., "svg|rect", "*|foo", "[html|lang]").
+ * (e.g. "svg|rect", "*|foo", "[html|lang]").
  */
 function findNamespacedTokens(tokens) {
   return tokens
@@ -341,7 +386,7 @@ function findNonContainerTarget(tokens) {
  *
  * Looks at the top-level final compound only; does not descend into
  * functional pseudos (`:is(form)`, `:where(...)`). Those patterns won't
- * satisfy the check, which is a deliberate simplification — the common
+ * satisfy the check, which is a deliberate simplification; the common
  * authoring patterns we want to accept are a `form` tag or an explicit role.
  */
 function hasFormAnchor(tokens) {
@@ -494,7 +539,7 @@ function containsNestingAmpersand(segment) {
  * individual CSS segments to parse independently.
  *
  * Known limitation: this is a naive string split and will misinterpret ">>>"
- * if it appears literally inside an attribute value (e.g., `[data-x=">>>"]`).
+ * if it appears literally inside an attribute value (e.g. `[data-x=">>>"]`).
  * This has not come up in practice for form selectors; if it does, this
  * should be replaced with a tokenizing split that respects bracket/quote
  * regions.
@@ -541,7 +586,7 @@ export function lintSelector(raw, location) {
 
   // Boundary combinator structural check. Collect any edge-misuse errors
   // and continue processing against the sanitized remainder so the author
-  // gets all applicable errors (e.g., boundary misuse *and* a bare-element
+  // gets all applicable errors (e.g. boundary misuse *and* a bare-element
   // target) in one pass rather than having to fix them serially.
   const { messages: boundaryMessages, sanitized } =
     checkBoundaryCombinator(raw);
@@ -603,7 +648,7 @@ export function lintSelector(raw, location) {
       continue;
     }
 
-    // Selector list (comma) check — fires once per segment
+    // Selector list (comma) check; fires once per segment
     if (parsedSelectors.length > 1) {
       errors.push({
         location: formattedLocation,
@@ -618,7 +663,7 @@ export function lintSelector(raw, location) {
     // Each group is an array of tokens.
     for (const tokens of parsedSelectors) {
       // Token-level checks that should also apply inside functional pseudos
-      // (e.g., :not(:nth-child(2)) still carries positional fragility).
+      // (e.g. :not(:nth-child(2)) still carries positional fragility).
       const allTokens = collectAllTokens(tokens);
 
       const atRuleTags = findAtRuleTags(allTokens);
@@ -639,7 +684,7 @@ export function lintSelector(raw, location) {
           selector: raw,
           message:
             `Pseudo-element ${pseudoElements.join(", ")} does not represent a real DOM element. ` +
-            `Target the underlying element directly (e.g., the \`input\` whose placeholder is styled, not \`::placeholder\`).`,
+            `Target the underlying element directly (e.g. the \`input\` whose placeholder is styled, not \`::placeholder\`).`,
         });
       }
 
@@ -665,8 +710,10 @@ export function lintSelector(raw, location) {
         });
       }
 
-      // Target-identity checks apply to the top-level compound only;
-      // :not(input) means "not an input", which is not the same as "target an input".
+      // Target-identity checks. These inspect the final compound only and
+      // are mutually exclusive: at most one fires per compound, with more
+      // specific rules taking precedence over the general missing-tag-anchor
+      // and pseudo-only fallbacks.
       if (hasUniversal(tokens)) {
         errors.push({
           location: formattedLocation,
@@ -681,7 +728,7 @@ export function lintSelector(raw, location) {
           selector: raw,
           message:
             `Bare element selector "${segment}" has no qualifying ID, attribute, or class. ` +
-            `Add a qualifier (e.g., \`input#id\`, \`input[name='x']\`, \`input.class\`) to avoid mis-targeting.`,
+            `Add a qualifier (e.g. \`input#id\`, \`input[name='x']\`) to avoid mis-targeting.`,
         });
       } else if (isClassOnly(tokens)) {
         errors.push({
@@ -689,11 +736,31 @@ export function lintSelector(raw, location) {
           selector: raw,
           message:
             `Class-only selector "${segment}" is not specific enough. ` +
-            `Add an element type or attribute qualifier (e.g., \`button.submit\`, \`.submit[type='submit']\`).`,
+            `Add an element tag and ID or attribute qualifier (e.g. \`button#submit\`, \`button.submit[type='submit']\`).`,
+        });
+      } else if (!isIdOnly(tokens) && lacksTagAnchor(tokens)) {
+        // Subsumes attribute-only, class+attribute, id+attribute, class+id,
+        // and other mixes that omit the element type. ID-only and class-only
+        // have their own specialized messages and fire above; this is the
+        // general fallback for everything else missing a tag anchor.
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Selector "${segment}" omits the element type. ` +
+            `Add a tag anchor (e.g. \`input[name='username']\`, \`button.submit\`) so the selector breaks if the target's element type changes; those changes warrant re-verification.`,
+        });
+      } else if (isPseudoOnly(tokens)) {
+        warnings.push({
+          location: formattedLocation,
+          selector: raw,
+          message:
+            `Pseudo-only selector "${segment}" has no target anchor. ` +
+            `Pseudo-classes qualify a target rather than identify one. Add a tag/id/class/attribute anchor (e.g. \`input:not([type='hidden'])\`).`,
         });
       }
 
-      // Deep nesting warning — top-level structural concern only.
+      // Deep nesting warning; top-level structural concern only.
       const depth = combinatorDepth(tokens);
       if (depth > MAX_COMBINATOR_DEPTH) {
         warnings.push({
@@ -763,12 +830,12 @@ export function lintSelector(raw, location) {
           selector: raw,
           message:
             `ID-only selector "${segment}" omits the element type. ` +
-            `Prefer including the element type (e.g., \`input#email\`) for added specificity and in cases where ids are (inappropriately) duplicated.`,
+            `Prefer including the element type (e.g. \`input#email\`) for added specificity and in cases where ids are (inappropriately) duplicated.`,
         });
       }
 
       // Empty-value attribute matcher errors (top-level only; nested
-      // inside :not() may be intentional — e.g., "has no class attr").
+      // inside :not() may be intentional; e.g. "has no class attr").
       const existenceEq = findExistenceEquivalentEmpty(tokens);
       if (existenceEq.length > 0) {
         const firstAttr = existenceEq[0].match(/\[(\w+)/)?.[1] ?? "attr";
@@ -964,7 +1031,7 @@ function lintCompositeSelectorArray(selectors, context, errors, warnings) {
 
 /**
  * Check for duplicate selector strings within a top-level alternatives array
- * (`selectorArray` or `compositeSelectorArray`). Non-string items (e.g., nested
+ * (`selectorArray` or `compositeSelectorArray`). Non-string items (e.g. nested
  * selector sequences) are skipped; duplicates inside a sequence are allowed
  * and handled by the caller.
  */

--- a/scripts/lib/lint-selectors.mjs
+++ b/scripts/lib/lint-selectors.mjs
@@ -418,6 +418,50 @@ function checkBoundaryCombinator(raw) {
 }
 
 /**
+ * Detect a CSS-nesting `&` at the selector level, ignoring `&` characters
+ * inside attribute brackets (`[href*="a&b"]`) and quoted strings.
+ *
+ * `css-what` throws on top-level `&` with messages like "Empty sub-selector"
+ * or "Unmatched selector: &", which don't point an author at the underlying
+ * mistake (copying from a SCSS/Tailwind/native-nesting stylesheet). Catching
+ * this before the parser lets us emit a targeted remediation instead.
+ */
+function containsNestingAmpersand(segment) {
+  let bracketDepth = 0;
+  let quote = null;
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i];
+    if (quote) {
+      if (ch === "\\") {
+        // Skip the escaped character so an escaped quote doesn't end the run.
+        i++;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "[") {
+      bracketDepth++;
+      continue;
+    }
+    if (ch === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+    if (ch === "&" && bracketDepth === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Split a selector string on the >>> boundary combinator, returning the
  * individual CSS segments to parse independently.
  *
@@ -501,6 +545,20 @@ export function lintSelector(raw, location) {
         message:
           `Segment between ">>>" combinators is empty or contains only whitespace. ` +
           `Remove the extra ">>>" or provide a selector for the boundary crossing.`,
+      });
+      continue;
+    }
+
+    // Pre-empt the parser on CSS nesting syntax. Otherwise `css-what` throws
+    // with a generic "Empty sub-selector" / "Unmatched selector: &" message
+    // that doesn't tell the author the real problem.
+    if (containsNestingAmpersand(segment)) {
+      errors.push({
+        location: formattedLocation,
+        selector: raw,
+        message:
+          `CSS nesting "&" in segment "${segment}" is a stylesheet construct, not a DOM query. ` +
+          `Remove the "&" and write out the full selector path.`,
       });
       continue;
     }

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -395,6 +395,47 @@ describe("at-rule tokens", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Errors: CSS nesting ampersand
+// ---------------------------------------------------------------------------
+
+describe("CSS nesting ampersand", () => {
+  it("reports an error for a leading & nesting selector", () => {
+    const errors = errorsFor("& input");
+    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    assert.equal(nestingErrors.length, 1);
+  });
+
+  it("reports an error for a trailing & nesting selector", () => {
+    const errors = errorsFor("input &");
+    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    assert.equal(nestingErrors.length, 1);
+  });
+
+  it("reports an error for & with a class qualifier", () => {
+    const errors = errorsFor("&.foo");
+    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    assert.equal(nestingErrors.length, 1);
+  });
+
+  it("reports per-segment across a >>> boundary", () => {
+    const errors = errorsFor("host-element >>> & input");
+    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    assert.equal(nestingErrors.length, 1);
+  });
+
+  it("does not flag an & inside an attribute value", () => {
+    const errors = errorsFor("a[href*='?a=1&b=2']");
+    assert.equal(errors.length, 0);
+  });
+
+  it("does not double-report the generic parse-error message", () => {
+    const errors = errorsFor("& input");
+    const parseErrors = errors.filter((e) => /Invalid CSS syntax/.test(e.message));
+    assert.equal(parseErrors.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Errors: namespace separator
 // ---------------------------------------------------------------------------
 

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -988,6 +988,110 @@ describe("container non-container target", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Warnings: container selector lacks a form anchor
+// ---------------------------------------------------------------------------
+
+describe("container form anchor", () => {
+  function containerLoc() {
+    return {
+      host: "example.com",
+      category: "account-login",
+      kind: "container",
+      key: "container",
+      selectorIndex: 0,
+    };
+  }
+
+  const anchorMatcher = (w) => /does not anchor on a form element/.test(w.message);
+
+  it("warns when a container targets a generic <div>", () => {
+    const { warnings } = lintSelector("div#login-wrapper", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 1);
+  });
+
+  it("warns when a container targets <section>", () => {
+    const { warnings } = lintSelector("section#auth", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 1);
+  });
+
+  it("does not warn for a `form` tag with an ID", () => {
+    const { warnings } = lintSelector("form#login", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("does not warn for a `form` tag with an attribute qualifier", () => {
+    const { warnings } = lintSelector("form[name='login']", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("does not warn for [role='form']", () => {
+    const { warnings } = lintSelector("[role='form']", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("does not warn for div[role='form']", () => {
+    const { warnings } = lintSelector("div[role='form']", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("accepts [role*='form'] (substring match)", () => {
+    const { warnings } = lintSelector("div[role*='form']", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("accepts [role~='form'] (word match in role list)", () => {
+    const { warnings } = lintSelector("div[role~='form']", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("only inspects the final >>> segment", () => {
+    // Left side is a div (no anchor), but the final segment is a form.
+    const { warnings } = lintSelector(
+      "div#outer >>> form#login",
+      containerLoc(),
+    );
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("warns when the final >>> segment lacks a form anchor", () => {
+    const { warnings } = lintSelector(
+      "iframe#frame >>> div#wrapper",
+      containerLoc(),
+    );
+    assert.equal(warnings.filter(anchorMatcher).length, 1);
+  });
+
+  it("does not stack onto the non-container-target warning", () => {
+    // `input` triggers the non-container-target warning; the form-anchor
+    // warning would be redundant noise on top of it.
+    const { warnings } = lintSelector("input#email", containerLoc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("does not fire when container is omitted entirely", () => {
+    const data = {
+      hosts: {
+        "example.com": {
+          forms: [
+            {
+              category: "account-login",
+              fields: { username: ["input#user"] },
+            },
+          ],
+        },
+      },
+    };
+    const { warnings } = lintMapData(data);
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+
+  it("does not fire on selectors under fields.*", () => {
+    const { warnings } = lintSelector("div#wrapper", loc());
+    assert.equal(warnings.filter(anchorMatcher).length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Warnings: selector length
 // ---------------------------------------------------------------------------
 

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -125,34 +125,37 @@ describe("universal selector", () => {
 // ---------------------------------------------------------------------------
 
 describe("bare element selector", () => {
-  it("reports an error for a bare tag", () => {
-    const errors = errorsFor("input");
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
+  it("warns for a bare tag", () => {
+    const warnings = warningsFor("input");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
   });
 
-  it("reports an error for a bare tag as the target of a descendant chain", () => {
-    const errors = errorsFor("form#login > input");
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
+  it("warns for a bare tag as the target of a descendant chain", () => {
+    const warnings = warningsFor("form#login > input");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
   });
 
   it("does not flag an element with an ID", () => {
     assert.equal(errorsFor("input#email").length, 0);
+    assert.equal(warningsFor("input#email").length, 0);
   });
 
   it("does not flag an element with a class", () => {
     assert.equal(errorsFor("input.username").length, 0);
+    assert.equal(warningsFor("input.username").length, 0);
   });
 
   it("does not flag an element with an attribute", () => {
     assert.equal(errorsFor("input[name='user']").length, 0);
+    assert.equal(warningsFor("input[name='user']").length, 0);
   });
 
   it("does not flag an element with a pseudo-class", () => {
     // Pseudo-classes qualify the element (may trigger a positional warning
-    // separately, but not a bare-element error)
-    assert.equal(errorsFor("input:first-child").length, 0);
+    // separately, but not a bare-element warning)
+    assert.equal(warningsFor("input:first-child").filter(w => /Bare element/.test(w.message)).length, 0);
   });
 });
 
@@ -217,32 +220,33 @@ describe("boundary combinator (>>>) structure", () => {
   });
 
   it("lints each segment independently", () => {
-    // Left side is fine, right side is a bare element
-    const errors = errorsFor("iframe#frame >>> input");
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
+    // Left side is fine, right side is a bare element (warning).
+    const { errors, warnings } = lintSelector("iframe#frame >>> input", loc());
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
   });
 
-  it("continues processing past a leading-boundary misuse to aggregate more errors", () => {
-    // ">>>" at start is reported, AND the bare-element target on the right
-    // is also flagged in the same pass.
-    const errors = errorsFor(">>> input");
+  it("continues processing past a leading-boundary misuse to aggregate more findings", () => {
+    // ">>>" at start is reported as an error, AND the bare-element target on
+    // the right is flagged as a warning in the same pass.
+    const { errors, warnings } = lintSelector(">>> input", loc());
     const startErr = errors.filter((e) => /starts with/.test(e.message));
-    const bareErr = errors.filter((e) =>
-      /Bare element selector/.test(e.message),
+    const bareWarn = warnings.filter((w) =>
+      /Bare element selector/.test(w.message),
     );
     assert.equal(startErr.length, 1);
-    assert.equal(bareErr.length, 1);
+    assert.equal(bareWarn.length, 1);
   });
 
-  it("continues processing past a trailing-boundary misuse to aggregate more errors", () => {
-    const errors = errorsFor("input >>>");
+  it("continues processing past a trailing-boundary misuse to aggregate more findings", () => {
+    const { errors, warnings } = lintSelector("input >>>", loc());
     const endErr = errors.filter((e) => /ends with/.test(e.message));
-    const bareErr = errors.filter((e) =>
-      /Bare element selector/.test(e.message),
+    const bareWarn = warnings.filter((w) =>
+      /Bare element selector/.test(w.message),
     );
     assert.equal(endErr.length, 1);
-    assert.equal(bareErr.length, 1);
+    assert.equal(bareWarn.length, 1);
   });
 
   it("reports both start and end boundary misuses when both are present", () => {
@@ -1112,10 +1116,11 @@ describe("lintMapData traversal", () => {
         },
       },
     };
-    const { errors } = lintMapData(data);
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
-    assert.match(errors[0].location, /\/login/);
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
+    assert.match(warnings[0].location, /\/login/);
   });
 
   it("skips null host entries", () => {
@@ -1178,10 +1183,11 @@ describe("lintMapData traversal", () => {
         },
       },
     };
-    const { errors } = lintMapData(data);
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
-    assert.match(errors[0].location, /actions\.submit/);
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
+    assert.match(warnings[0].location, /actions\.submit/);
   });
 
   it("lints selector sequences in composite arrays", () => {
@@ -1199,10 +1205,11 @@ describe("lintMapData traversal", () => {
         },
       },
     };
-    const { errors } = lintMapData(data);
-    assert.equal(errors.length, 1);
-    assert.match(errors[0].message, /Bare element selector/);
-    assert.match(errors[0].location, /sequence\[0\]/);
+    const { errors, warnings } = lintMapData(data);
+    assert.equal(errors.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /Bare element selector/);
+    assert.match(warnings[0].location, /sequence\[0\]/);
   });
 
   it("returns empty results when hosts is absent", () => {

--- a/scripts/lib/lint-selectors.test.mjs
+++ b/scripts/lib/lint-selectors.test.mjs
@@ -155,7 +155,12 @@ describe("bare element selector", () => {
   it("does not flag an element with a pseudo-class", () => {
     // Pseudo-classes qualify the element (may trigger a positional warning
     // separately, but not a bare-element warning)
-    assert.equal(warningsFor("input:first-child").filter(w => /Bare element/.test(w.message)).length, 0);
+    assert.equal(
+      warningsFor("input:first-child").filter((w) =>
+        /Bare element/.test(w.message),
+      ).length,
+      0,
+    );
   });
 });
 
@@ -401,25 +406,33 @@ describe("at-rule tokens", () => {
 describe("CSS nesting ampersand", () => {
   it("reports an error for a leading & nesting selector", () => {
     const errors = errorsFor("& input");
-    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    const nestingErrors = errors.filter((e) =>
+      /CSS nesting "&"/.test(e.message),
+    );
     assert.equal(nestingErrors.length, 1);
   });
 
   it("reports an error for a trailing & nesting selector", () => {
     const errors = errorsFor("input &");
-    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    const nestingErrors = errors.filter((e) =>
+      /CSS nesting "&"/.test(e.message),
+    );
     assert.equal(nestingErrors.length, 1);
   });
 
   it("reports an error for & with a class qualifier", () => {
     const errors = errorsFor("&.foo");
-    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    const nestingErrors = errors.filter((e) =>
+      /CSS nesting "&"/.test(e.message),
+    );
     assert.equal(nestingErrors.length, 1);
   });
 
   it("reports per-segment across a >>> boundary", () => {
     const errors = errorsFor("host-element >>> & input");
-    const nestingErrors = errors.filter((e) => /CSS nesting "&"/.test(e.message));
+    const nestingErrors = errors.filter((e) =>
+      /CSS nesting "&"/.test(e.message),
+    );
     assert.equal(nestingErrors.length, 1);
   });
 
@@ -430,7 +443,9 @@ describe("CSS nesting ampersand", () => {
 
   it("does not double-report the generic parse-error message", () => {
     const errors = errorsFor("& input");
-    const parseErrors = errors.filter((e) => /Invalid CSS syntax/.test(e.message));
+    const parseErrors = errors.filter((e) =>
+      /Invalid CSS syntax/.test(e.message),
+    );
     assert.equal(parseErrors.length, 0);
   });
 });
@@ -780,14 +795,19 @@ describe("ID-only target", () => {
     assert.equal(warnings.length, 0);
   });
 
-  it("does not warn when a class qualifies the ID", () => {
+  it("does not fire the ID-only warning when a class qualifies the ID", () => {
+    // The class qualifier disqualifies isIdOnly (length > 1), but the
+    // missing-tag warning still fires under the new rule — that's
+    // covered in its own suite.
     const warnings = warningsFor("#email.primary");
-    assert.equal(warnings.length, 0);
+    const idOnly = warnings.filter((w) => /ID-only selector/.test(w.message));
+    assert.equal(idOnly.length, 0);
   });
 
-  it("does not warn when an attribute qualifies the ID", () => {
+  it("does not fire the ID-only warning when an attribute qualifies the ID", () => {
     const warnings = warningsFor("#email[type='email']");
-    assert.equal(warnings.length, 0);
+    const idOnly = warnings.filter((w) => /ID-only selector/.test(w.message));
+    assert.equal(idOnly.length, 0);
   });
 });
 
@@ -988,6 +1008,209 @@ describe("container non-container target", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Warnings: missing tag anchor (general "no element type" fallback)
+// ---------------------------------------------------------------------------
+
+describe("missing tag anchor", () => {
+  // Distinct from the ID-only message (which also contains "omits the
+  // element type"). Match on the remediation-specific phrase instead.
+  const missingTagMatcher = (w) => /Add a tag anchor/.test(w.message);
+
+  it("warns on attribute-only selector [name='username']", () => {
+    const warnings = warningsFor("[name='username']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on attribute-only selector [type='submit']", () => {
+    const warnings = warningsFor("[type='submit']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on attribute-only selector [role='form']", () => {
+    const warnings = warningsFor("[role='form']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on attribute-only selector [data-testid='login']", () => {
+    const warnings = warningsFor("[data-testid='login']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on class+attribute mix .foo[name='x']", () => {
+    const warnings = warningsFor(".foo[name='x']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on id+attribute mix #x[name='y']", () => {
+    const warnings = warningsFor("#x[name='y']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on class+id mix .foo#x", () => {
+    const warnings = warningsFor(".foo#x");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("warns on multi-class+attribute .foo.bar[name='x']", () => {
+    const warnings = warningsFor(".foo.bar[name='x']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("only inspects the final compound in a descendant chain", () => {
+    // Left side has no tag, right side does — should not fire.
+    const warnings = warningsFor("#wrapper > input[name='x']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 0);
+  });
+
+  it("warns when the final compound in a chain lacks a tag", () => {
+    const warnings = warningsFor("form#login > [name='username']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("checks each >>> segment independently", () => {
+    // The rule applies per-segment: a tag-less left side fires its own
+    // missing-tag warning, regardless of how qualified the right side is.
+    const { warnings } = lintSelector(
+      "[data-frame='outer'] >>> input[name='x']",
+      loc(),
+    );
+    assert.equal(warnings.filter(missingTagMatcher).length, 1);
+  });
+
+  it("does not fire on >>> chains where every segment has a tag", () => {
+    const { warnings } = lintSelector(
+      "iframe#outer >>> input[name='x']",
+      loc(),
+    );
+    assert.equal(warnings.filter(missingTagMatcher).length, 0);
+  });
+
+  it("does not fire on a tag-qualified selector", () => {
+    assert.equal(
+      warningsFor("input[name='x']").filter(missingTagMatcher).length,
+      0,
+    );
+    assert.equal(
+      warningsFor("button.submit").filter(missingTagMatcher).length,
+      0,
+    );
+    assert.equal(warningsFor("form#login").filter(missingTagMatcher).length, 0);
+  });
+
+  it("does not double-fire with id-only", () => {
+    // `[id='x']` triggers id-only; the general missing-tag warning should
+    // step aside so the more specific message wins.
+    const warnings = warningsFor("[id='x']");
+    assert.equal(warnings.filter(missingTagMatcher).length, 0);
+  });
+
+  it("does not fire on class-only (class-only error wins)", () => {
+    const { errors, warnings } = lintSelector(".submit", loc());
+    assert.equal(errors.filter((e) => /Class-only/.test(e.message)).length, 1);
+    assert.equal(warnings.filter(missingTagMatcher).length, 0);
+  });
+
+  it("does not fire on bare-element (it has a tag)", () => {
+    const warnings = warningsFor("input");
+    assert.equal(warnings.filter(missingTagMatcher).length, 0);
+  });
+
+  it("does not fire on pseudo-only selectors (handled by isPseudoOnly)", () => {
+    // Pseudo-only selectors get their own dedicated warning; the
+    // missing-tag rule should step aside so the more specific message wins.
+    assert.equal(warningsFor(":hover").filter(missingTagMatcher).length, 0);
+    assert.equal(
+      warningsFor(":not(input)").filter(missingTagMatcher).length,
+      0,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings: pseudo-only selectors
+// ---------------------------------------------------------------------------
+
+describe("pseudo-only selector", () => {
+  const pseudoOnlyMatcher = (w) => /Pseudo-only selector/.test(w.message);
+
+  it("warns on a bare state pseudo (`:hover`)", () => {
+    const warnings = warningsFor(":hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("warns on a bare functional pseudo (`:not(input)`)", () => {
+    const warnings = warningsFor(":not(input)");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("warns on a bare positional pseudo (`:first-child`)", () => {
+    const warnings = warningsFor(":first-child");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("warns on a bare relational pseudo (`:has(input)`)", () => {
+    const warnings = warningsFor(":has(input)");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("warns on a bare logical-OR pseudo (`:is(form)`)", () => {
+    const warnings = warningsFor(":is(form)");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("warns when multiple pseudos stack with no anchor", () => {
+    const warnings = warningsFor(":not([type='hidden']):hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("does not fire when a tag anchors the compound", () => {
+    assert.equal(
+      warningsFor("input:hover").filter(pseudoOnlyMatcher).length,
+      0,
+    );
+    assert.equal(
+      warningsFor("input:not([type='hidden'])").filter(pseudoOnlyMatcher)
+        .length,
+      0,
+    );
+  });
+
+  it("does not fire when an attribute anchors the compound", () => {
+    // `[name='x']:hover` triggers the missing-tag-anchor warning instead.
+    const warnings = warningsFor("[name='x']:hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 0);
+  });
+
+  it("does not fire when an id anchors the compound", () => {
+    const warnings = warningsFor("#email:hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 0);
+  });
+
+  it("does not fire when a class anchors the compound", () => {
+    const warnings = warningsFor(".submit:hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 0);
+  });
+
+  it("only inspects the final compound in a descendant chain", () => {
+    // The final compound has a tag — no pseudo-only warning, even though
+    // the chain starts with a pseudo-only compound.
+    const warnings = warningsFor(":hover > input[name='x']");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 0);
+  });
+
+  it("warns when the final compound in a chain is pseudo-only", () => {
+    const warnings = warningsFor("form#login > :hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+
+  it("checks each >>> segment independently", () => {
+    // Right segment is pseudo-only; left side has a tag.
+    const warnings = warningsFor("iframe#frame >>> :hover");
+    assert.equal(warnings.filter(pseudoOnlyMatcher).length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Warnings: container selector lacks a form anchor
 // ---------------------------------------------------------------------------
 
@@ -1002,7 +1225,8 @@ describe("container form anchor", () => {
     };
   }
 
-  const anchorMatcher = (w) => /does not anchor on a form element/.test(w.message);
+  const anchorMatcher = (w) =>
+    /does not anchor on a form element/.test(w.message);
 
   it("warns when a container targets a generic <div>", () => {
     const { warnings } = lintSelector("div#login-wrapper", containerLoc());


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38221](https://bitwarden.atlassian.net/browse/PM-38221)

## 📔 Objective

- update linting rules to check for tagless selectors
- make remark linting rules consistent with formatting rules
- update docs to clarify selector goals and philosophies
- warn if there is no form tag or role in the final segment of the container selector
- add linting rule to defend against nesting ampersands at the selector level
- add linter tests to build checks to prevent future drift
- update linter tests to match updated linter logic

[PM-38221]: https://bitwarden.atlassian.net/browse/PM-38221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ