### PR TITLE
[PM-38471] Update Forms Map version from pre-release to v1

### DIFF
--- a/maps/forms/README.md
+++ b/maps/forms/README.md
@@ -10,15 +10,6 @@ describes the user-facing concept of users supplying data to a website, which
 may or may not utilize the HTML `form` tag. See the project
 [README](../../README.md) for broader mapping philosophies.
 
-> [!IMPORTANT]
-> The Forms Map is currently a **prerelease** Map (`schemaVersion` `0.y.z`).
-> Its schema, field/action key sets, value semantics, and host entries may
-> change in any way between releases, and the Map itself may be dropped from
-> a release without notice. The "Schema Version Bumps" rubric below describes
-> the rules that will apply once the Map graduates to `1.0.0`.
-> See the project README's [Prerelease Maps](../../README.md#prerelease-maps)
-> section for full prerelease semantics.
-
 - [Forms Map](#forms-map)
   - [Limitations](#limitations)
   - [Schema Version Bumps](#schema-version-bumps)
@@ -92,7 +83,7 @@ bump for the Forms Map schema:
 
 ```jsonc
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "1.0.0",
   "hosts": {
     "<host>": {
       "forms": [ ... ],           // optional — site-wide fallback
@@ -112,7 +103,7 @@ A complex entry may look like:
 
 ```json
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "1.0.0",
   "hosts": {
     "example.com": {
       "forms": [
@@ -232,7 +223,7 @@ must start with `/`.
 
 ```json
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "1.0.0",
   "hosts": {
     "example.com": {
       "forms": [

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "1.0.0",
   "hosts": {
     "bankofamerica.com": {
       "forms": [

--- a/maps/forms/forms.v1.schema.json
+++ b/maps/forms/forms.v1.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/bitwarden/map-the-web/main/maps/forms/forms.v0.schema.json",
-  "title": "Forms Map (prerelease)",
-  "description": "Describes the locations of form fields on web pages using CSS selectors. This Map is in prerelease (schemaVersion 0.y.z); its shape and contents may change without notice. See README.md for full documentation.",
+  "$id": "https://raw.githubusercontent.com/bitwarden/map-the-web/main/maps/forms/forms.v1.schema.json",
+  "title": "Forms Map",
+  "description": "Describes the locations of form fields on web pages using CSS selectors. See README.md for full documentation.",
   "type": "object",
   "properties": {
     "schemaVersion": {
       "type": "string",
-      "const": "0.1.0",
+      "const": "1.0.0",
       "description": "Schema version this file conforms to. Must match the version expected by the schema."
     },
     "hosts": {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38471](https://bitwarden.atlassian.net/browse/PM-38471)

## 📔 Objective

These changes signal that the Forms Map has exited pre-release and is ready for consumption.

Note, this does NOT include removing the admonition/warning from the project README indicating the project’s current experimental state as a whole.


[PM-38471]: https://bitwarden.atlassian.net/browse/PM-38471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ