### PR TITLE
[PM-38607] Remove incomplete test entry from webtests.dev Forms map

### DIFF
--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -234,20 +234,6 @@
     },
     "webtests.dev": {
       "pathnames": {
-        "/forms/login/simple": {
-          "forms": [
-            {
-              "category": "account-login",
-              "container": ["form[action='/login']"],
-              "fields": {
-                "username": ["input#username"]
-              },
-              "actions": {
-                "submit": ["form[action='/login'] button[type='submit']"]
-              }
-            }
-          ]
-        },
         "/forms/login/ambiguous-inputs": {
           "forms": [
             {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38607](https://bitwarden.atlassian.net/browse/PM-38607)

## 📔 Objective

Remove a deliberately (used for testing) incomplete map entry for https://webtests.dev/forms/login/simple/ that was meant to come out of the Forms map.

[PM-38607]: https://bitwarden.atlassian.net/browse/PM-38607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ