### PR TITLE
[PM-38895] Add null case to webtests.dev

### DIFF
--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -296,6 +296,8 @@
             }
           ]
         },
+        // Page is marked as irrelevant as a diagnostic case. The page purpose is to exemplify strong form semantics.
+        "/forms/login/simple-spec": null,
         "/forms/login/shadow-root-inputs-closed": {
           "forms": [
             {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38895](https://bitwarden.atlassian.net/browse/PM-38895)

## 📔 Objective

`/forms/login/simple-spec/` should be marked as irrelevant (`null`) to enable consumers test their implementation of the Forms map. The page was chosen for it’s goal of exemplifying strong form semantics in a test setting.

[PM-38895]: https://bitwarden.atlassian.net/browse/PM-38895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ