### PR TITLE
[PM-40227] Drop the selector length check from linter

### DIFF
--- a/scripts/lib/lint-selectors.mts
+++ b/scripts/lib/lint-selectors.mts
@@ -25,7 +25,6 @@ type NamespacedSelector = AttributeSelector | TagSelector | UniversalSelector;
 
 const BOUNDARY_COMBINATOR = ">>>";
 const MAX_COMBINATOR_DEPTH = 4;
-const MAX_SELECTOR_LENGTH = 200;
 
 const COMBINATOR_TYPES = new Set([
   "child",
@@ -612,17 +611,6 @@ export function lintSelector(raw: string, location: Location): LintResult {
         `Remove the entry or provide a valid selector.`,
     });
     return { errors, warnings };
-  }
-
-  // Length warning
-  if (raw.length > MAX_SELECTOR_LENGTH) {
-    warnings.push({
-      location: formattedLocation,
-      selector: raw,
-      message:
-        `Selector is ${raw.length} characters long (>${MAX_SELECTOR_LENGTH}). ` +
-        `Consider scoping with a "container" or simplifying the selector chain.`,
-    });
   }
 
   // Boundary combinator structural check. Collect any edge-misuse errors

--- a/scripts/lib/lint-selectors.test.mts
+++ b/scripts/lib/lint-selectors.test.mts
@@ -1318,28 +1318,6 @@ describe("container form anchor", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Warnings: selector length
-// ---------------------------------------------------------------------------
-
-describe("selector length", () => {
-  it("warns when selector exceeds 200 characters", () => {
-    const long = "div#" + "a".repeat(197);
-    assert.ok(long.length > 200);
-    const warnings = warningsFor(long);
-    const length = warnings.filter((w) => /characters long/.test(w.message));
-    assert.equal(length.length, 1);
-  });
-
-  it("does not warn at exactly 200 characters", () => {
-    const exact = "div#" + "a".repeat(196);
-    assert.equal(exact.length, 200);
-    const warnings = warningsFor(exact);
-    const length = warnings.filter((w) => /characters long/.test(w.message));
-    assert.equal(length.length, 0);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Errors: duplicates
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40227](https://bitwarden.atlassian.net/browse/PM-40227)

## 📔 Objective

The selector linter warning for selector length doesn’t add any value to the selectors and can actively guide authors away from desired practices. As such, we’re removing the length check and warning.

[PM-40227]: https://bitwarden.atlassian.net/browse/PM-40227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ