### PR TITLE
[PM-41496] Fill Assist Rule: https://www.christianbook.com

### DIFF
--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -188,7 +188,7 @@
               }
             },
             {
-              "category": "identity",
+              "category": "account-creation",
               "container": ["form#login_form div.CBD-Form-Login-alternate"],
               "fields": {
                 "email": [

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -151,6 +151,22 @@
       ]
     },
     "christianbook.com": {
+      "forms": [
+        {
+          "category": "search",
+          "container": ["form#search-form"],
+          "fields": {
+            "searchTerm": [
+              "form#search-form input#Ntt[name='Ntt'][type='text']"
+            ]
+          },
+          "actions": {
+            "submit": [
+              "form#search-form button#search[name='search'][type='submit']"
+            ]
+          }
+        }
+      ],
       "pathnames": {
         "/apps/login": {
           "forms": [
@@ -170,6 +186,76 @@
                   "form#login_form div.CBD-Form-Login-main button[name='login_continue.x'][type='submit']"
                 ]
               }
+            },
+            {
+              "category": "identity",
+              "container": ["form#login_form div.CBD-Form-Login-alternate"],
+              "fields": {
+                "email": [
+                  "form#login_form div.CBD-Form-Login-alternate input#new_cust_email[name='new_cust_email'][type='email']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#login_form div.CBD-Form-Login-alternate button#create_account[name='login_continue.x'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "signup",
+              "container": ["form#footer-email-signup-form"],
+              "fields": {
+                "email": [
+                  "form#footer-email-signup-form input[name='nav-email-address'][type='email']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#footer-email-signup-form input[name='signup'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "signup",
+              "container": ["form#mob-email-signup-form"],
+              "fields": {
+                "email": [
+                  "form#mob-email-signup-form input[name='nav-email-address'][type='email']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#mob-email-signup-form input[name='signup'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "signup",
+              "container": ["form#top-nav-email-signup-form"],
+              "fields": {
+                "email": [
+                  "form#top-nav-email-signup-form input#nav-email-address[name='nav-email-address'][type='text']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#top-nav-email-signup-form input#signup[name='signup'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "search",
+              "container": ["form#search-form"],
+              "fields": {
+                "searchTerm": [
+                  "form#search-form input#Ntt[name='Ntt'][type='text']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#search-form button#search[name='search'][type='submit']"
+                ]
+              }
             }
           ]
         },
@@ -177,14 +263,26 @@
           "forms": [
             {
               "category": "account-creation",
-              "container": ["form#account-setup"],
+              "container": ["form#account-setup div.CBD-Account-Setup"],
               "fields": {
                 "email": [
                   "form#account-setup input#email[name='email'][type='text']"
                 ],
                 "newPassword": [
-                  "form#account-setup input#password[name='password'][type='password']"
-                ],
+                  "form#account-setup input#password[name='password'][type='password']",
+                  "form#account-setup input#verify_password[name='verify_password'][type='password']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#account-setup button[name='create_account'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "address",
+              "container": ["form#account-setup div#billing"],
+              "fields": {
                 "firstName": [
                   "form#account-setup input#billing_first_name[name='billing_first_name']"
                 ],
@@ -215,19 +313,19 @@
                   "form#account-setup select#billing_state-all",
                   "form#account-setup input#billing_state-intl"
                 ]
-              },
-              "actions": {
-                "submit": [
-                  "form#account-setup button[name='create_account'][type='submit']"
-                ]
               }
             },
             {
-              "category": "account-creation",
-              "container": ["form#account-setup"],
+              "category": "search",
+              "container": ["form#search-form"],
               "fields": {
-                "newPassword": [
-                  "form#account-setup input#verify_password[name='verify_password'][type='password']"
+                "searchTerm": [
+                  "form#search-form input#Ntt[name='Ntt'][type='text']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#search-form button#search[name='search'][type='submit']"
                 ]
               }
             }

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -165,6 +165,20 @@
               "form#search-form button#search[name='search'][type='submit']"
             ]
           }
+        },
+        {
+          "category": "signup",
+          "container": ["form#footer-email-signup-form"],
+          "fields": {
+            "email": [
+              "form#footer-email-signup-form input[name='nav-email-address'][type='email']"
+            ]
+          },
+          "actions": {
+            "submit": [
+              "form#footer-email-signup-form input[name='signup'][type='submit']"
+            ]
+          }
         }
       ],
       "pathnames": {
@@ -198,34 +212,6 @@
               "actions": {
                 "submit": [
                   "form#login_form div.CBD-Form-Login-alternate button#create_account[name='login_continue.x'][type='submit']"
-                ]
-              }
-            },
-            {
-              "category": "signup",
-              "container": ["form#footer-email-signup-form"],
-              "fields": {
-                "email": [
-                  "form#footer-email-signup-form input[name='nav-email-address'][type='email']"
-                ]
-              },
-              "actions": {
-                "submit": [
-                  "form#footer-email-signup-form input[name='signup'][type='submit']"
-                ]
-              }
-            },
-            {
-              "category": "search",
-              "container": ["form#search-form"],
-              "fields": {
-                "searchTerm": [
-                  "form#search-form input#Ntt[name='Ntt'][type='text']"
-                ]
-              },
-              "actions": {
-                "submit": [
-                  "form#search-form button#search[name='search'][type='submit']"
                 ]
               }
             }
@@ -284,20 +270,6 @@
                   "form#account-setup select#billing_state-canada",
                   "form#account-setup select#billing_state-all",
                   "form#account-setup input#billing_state-intl"
-                ]
-              }
-            },
-            {
-              "category": "search",
-              "container": ["form#search-form"],
-              "fields": {
-                "searchTerm": [
-                  "form#search-form input#Ntt[name='Ntt'][type='text']"
-                ]
-              },
-              "actions": {
-                "submit": [
-                  "form#search-form button#search[name='search'][type='submit']"
                 ]
               }
             }

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -217,6 +217,41 @@
             }
           ]
         },
+        "/apps/account": {
+          "forms": [
+            {
+              "category": "account-login",
+              "container": ["form#login_form div.CBD-Form-Login-main"],
+              "fields": {
+                "email": [
+                  "form#login_form div.CBD-Form-Login-main input#email[name='email'][type='email']"
+                ],
+                "password": [
+                  "form#login_form div.CBD-Form-Login-main input#password[name='password'][type='password']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#login_form div.CBD-Form-Login-main button[name='login_continue.x'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "account-creation",
+              "container": ["form#login_form div.CBD-Form-Login-alternate"],
+              "fields": {
+                "email": [
+                  "form#login_form div.CBD-Form-Login-alternate input#new_cust_email[name='new_cust_email'][type='email']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#login_form div.CBD-Form-Login-alternate button#create_account[name='login_continue.x'][type='submit']"
+                ]
+              }
+            }
+          ]
+        },
         "/apps/account/setup": {
           "forms": [
             {

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -216,34 +216,6 @@
               }
             },
             {
-              "category": "signup",
-              "container": ["form#mob-email-signup-form"],
-              "fields": {
-                "email": [
-                  "form#mob-email-signup-form input[name='nav-email-address'][type='email']"
-                ]
-              },
-              "actions": {
-                "submit": [
-                  "form#mob-email-signup-form input[name='signup'][type='submit']"
-                ]
-              }
-            },
-            {
-              "category": "signup",
-              "container": ["form#top-nav-email-signup-form"],
-              "fields": {
-                "email": [
-                  "form#top-nav-email-signup-form input#nav-email-address[name='nav-email-address'][type='text']"
-                ]
-              },
-              "actions": {
-                "submit": [
-                  "form#top-nav-email-signup-form input#signup[name='signup'][type='submit']"
-                ]
-              }
-            },
-            {
               "category": "search",
               "container": ["form#search-form"],
               "fields": {

--- a/maps/forms/forms.jsonc
+++ b/maps/forms/forms.jsonc
@@ -150,6 +150,91 @@
         }
       ]
     },
+    "christianbook.com": {
+      "pathnames": {
+        "/apps/login": {
+          "forms": [
+            {
+              "category": "account-login",
+              "container": ["form#login_form div.CBD-Form-Login-main"],
+              "fields": {
+                "email": [
+                  "form#login_form div.CBD-Form-Login-main input#email[name='email'][type='email']"
+                ],
+                "password": [
+                  "form#login_form div.CBD-Form-Login-main input#password[name='password'][type='password']"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#login_form div.CBD-Form-Login-main button[name='login_continue.x'][type='submit']"
+                ]
+              }
+            }
+          ]
+        },
+        "/apps/account/setup": {
+          "forms": [
+            {
+              "category": "account-creation",
+              "container": ["form#account-setup"],
+              "fields": {
+                "email": [
+                  "form#account-setup input#email[name='email'][type='text']"
+                ],
+                "newPassword": [
+                  "form#account-setup input#password[name='password'][type='password']"
+                ],
+                "firstName": [
+                  "form#account-setup input#billing_first_name[name='billing_first_name']"
+                ],
+                "lastName": [
+                  "form#account-setup input#billing_last_name[name='billing_last_name']"
+                ],
+                "organization": [
+                  "form#account-setup input#billing_organization[name='billing_organization']"
+                ],
+                "country": [
+                  "form#account-setup select#billing_nation[name='billing_nation']"
+                ],
+                "addressLine1": [
+                  "form#account-setup input#billing_street[name='billing_street']"
+                ],
+                "addressLine2": [
+                  "form#account-setup input#billing_auxiliary[name='billing_auxiliary']"
+                ],
+                "postalCode": [
+                  "form#account-setup input#billing_zip[name='billing_zip']"
+                ],
+                "addressLevel2": [
+                  "form#account-setup input#billing_city[name='billing_city']"
+                ],
+                "addressLevel1": [
+                  "form#account-setup select#billing_state-usa[name='billing_state']",
+                  "form#account-setup select#billing_state-canada",
+                  "form#account-setup select#billing_state-all",
+                  "form#account-setup input#billing_state-intl"
+                ]
+              },
+              "actions": {
+                "submit": [
+                  "form#account-setup button[name='create_account'][type='submit']"
+                ]
+              }
+            },
+            {
+              "category": "account-creation",
+              "container": ["form#account-setup"],
+              "fields": {
+                "newPassword": [
+                  "form#account-setup input#verify_password[name='verify_password'][type='password']"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "eversource.com": {
       "pathnames": {
         "/security/account/login": {


### PR DESCRIPTION

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41496
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Maps christianbook.com /apps/login as account-login (login panel only) and /apps/account/setup as account-creation (credentials, profile, and billing address). Password and Verify Password use separate form entries so each newPassword field is targeted; create-account and footer newsletter emails on login stay unmapped to avoid identity fill spraying; country-dependent state/province controls are alternatives under addressLevel1.

> [!NOTE]
> Did not map the two other email fields because they would cause unintended behavior which would have to be handled by clients repo. All email fields on the page fill if either one of these identity fields were filled. 
<img width="1315" height="651" alt="Screenshot 2026-08-20 at 4 54 29 PM" src="https://github.com/user-attachments/assets/8055251f-673d-485b-982e-b92dcb217cf6" />

## 📸 Screenshots


https://github.com/user-attachments/assets/f101c8fe-1b42-441c-b07c-4f16772c77a7





https://github.com/user-attachments/assets/59a14a41-2a2a-4dac-b56b-107bdd651c52


